### PR TITLE
TINSTL-1948 - Fix installation for SJS, TDP, StreamsRunner and TCOMP.

### DIFF
--- a/ansible/roles/sjs/tasks/main.yml
+++ b/ansible/roles/sjs/tasks/main.yml
@@ -19,6 +19,10 @@
 - include_tasks: ../../common/tasks/install_rpm.yml
   when: install_prefix != '/opt/talend'
 
+# Patch installation if installing into non-default folder
+- include_tasks: patch.yml
+  when: install_prefix != '/opt/talend'
+
 # Update configuration
 - import_tasks: update_config_installed.yml
 

--- a/ansible/roles/sjs/tasks/patch.yml
+++ b/ansible/roles/sjs/tasks/patch.yml
@@ -1,0 +1,37 @@
+---
+# This script is used to patch existing issues in SJS RPM, when installed
+#   into non-default folder.
+# There are 2 issues:
+#   1. 'settings.sh' file is absent - it must point on /etc/talend/sjs/settings.sh
+#   2. systemd descriptor contains hard-coded /opt/talend
+
+- name: Get status of 'settings.sh' file
+  stat:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/settings.sh"
+  register: sjs_config_file_stat
+
+- name: Remove 'settings.sh' file
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/settings.sh"
+    state: absent
+  when: sjs_config_file_stat.stat.exists and not sjs_config_file_stat.stat.islink
+
+- name: Recreate 'settings.sh' as link
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/settings.sh"
+    src: "/etc/talend/{{ rpm_folder }}/settings.sh"
+    state: link
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
+
+# Update systemd descriptor
+- name: Update systemd descriptor file for SJS
+  replace:
+    path: "/etc/systemd/system/{{ app_service }}.service"
+    regexp: "/opt/talend/"
+    replace: "{{ install_prefix }}/"
+
+- name: Reload changes in systemd descriptor file
+  shell: "systemctl daemon-reload"
+  args:
+    warn: no
+  changed_when: false

--- a/ansible/roles/streamsrunner/tasks/main.yml
+++ b/ansible/roles/streamsrunner/tasks/main.yml
@@ -19,6 +19,10 @@
 - include_tasks: ../../common/tasks/install_rpm.yml
   when: install_prefix != '/opt/talend'
 
+# Patch installation if installing into non-default folder
+- include_tasks: patch.yml
+  when: install_prefix != '/opt/talend'
+
 # Update configuration
 - import_tasks: update_config_installed.yml
 

--- a/ansible/roles/streamsrunner/tasks/patch.yml
+++ b/ansible/roles/streamsrunner/tasks/patch.yml
@@ -1,0 +1,37 @@
+---
+# This script is used to patch existing issues in StreamsRunner RPM, when installed
+#   into non-default folder.
+# There are 2 issues:
+#   1. 'config' folder is empty - it must point on /etc/talend/streamsrunner
+#   2. systemd descriptor contains hard-coded /opt/talend
+
+- name: Get status of 'conf' folder
+  stat:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/conf"
+  register: str_conf_folder_stat
+
+- name: Remove 'conf' folder
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/conf"
+    state: absent
+  when: str_conf_folder_stat.stat.exists and str_conf_folder_stat.stat.isdir
+
+- name: Recreate 'conf' as link
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/conf"
+    src: "/etc/talend/{{ rpm_folder }}"
+    state: link
+  when: str_conf_folder_stat.stat.exists and str_conf_folder_stat.stat.isdir
+
+# Update systemd descriptor
+- name: Update systemd descriptor file for StreamsRunner
+  replace:
+    path: "/etc/systemd/system/{{ app_service }}.service"
+    regexp: "/opt/talend/"
+    replace: "{{ install_prefix }}/"
+
+- name: Reload changes in systemd descriptor file
+  shell: "systemctl daemon-reload"
+  args:
+    warn: no
+  changed_when: false

--- a/ansible/roles/tcomp/tasks/main.yml
+++ b/ansible/roles/tcomp/tasks/main.yml
@@ -19,6 +19,10 @@
 - include_tasks: ../../common/tasks/install_rpm.yml
   when: install_prefix != '/opt/talend'
 
+# Patch installation if installing into non-default folder
+- include_tasks: patch.yml
+  when: install_prefix != '/opt/talend'
+
 # Update configuration
 - import_tasks: update_config_installed.yml
 

--- a/ansible/roles/tcomp/tasks/patch.yml
+++ b/ansible/roles/tcomp/tasks/patch.yml
@@ -1,0 +1,37 @@
+---
+# This script is used to patch existing issues in TCOMP RPM, when installed
+#   into non-default folder.
+# There are 2 issues:
+#   1. 'config' folder is empty - it must point on /etc/talend/tcomp
+#   2. systemd descriptor contains hard-coded /opt/talend
+
+- name: Get status of 'config' folder
+  stat:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+  register: tcomp_config_folder_stat
+
+- name: Remove 'config' folder
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+    state: absent
+  when: tcomp_config_folder_stat.stat.exists and tcomp_config_folder_stat.stat.isdir
+
+- name: Recreate 'config' as link
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+    src: "/etc/talend/{{ rpm_folder }}"
+    state: link
+  when: tcomp_config_folder_stat.stat.exists and tcomp_config_folder_stat.stat.isdir
+
+# Update systemd descriptor
+- name: Update systemd descriptor file for TCOMP
+  replace:
+    path: "/etc/systemd/system/{{ app_service }}.service"
+    regexp: "/opt/talend/"
+    replace: "{{ install_prefix }}/"
+
+- name: Reload changes in systemd descriptor file
+  shell: "systemctl daemon-reload"
+  args:
+    warn: no
+  changed_when: false

--- a/ansible/roles/tdp/tasks/main.yml
+++ b/ansible/roles/tdp/tasks/main.yml
@@ -19,6 +19,10 @@
 - include_tasks: ../../common/tasks/install_rpm.yml
   when: install_prefix != '/opt/talend'
 
+# Patch installation if installing into non-default folder
+- include_tasks: patch.yml
+  when: install_prefix != '/opt/talend'
+
 # Update configuration
 - import_tasks: update_config_installed.yml
 

--- a/ansible/roles/tdp/tasks/patch.yml
+++ b/ansible/roles/tdp/tasks/patch.yml
@@ -1,0 +1,37 @@
+---
+# This script is used to patch existing issues in TDP RPM, when installed
+#   into non-default folder.
+# There are 2 issues:
+#   1. 'config' folder is empty - it must point on /etc/talend/tdp
+#   2. systemd descriptor contains hard-coded /opt/talend
+
+- name: Get status of 'config' folder
+  stat:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+  register: tdp_config_folder_stat
+
+- name: Remove 'config' folder
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+    state: absent
+  when: tdp_config_folder_stat.stat.exists and tdp_config_folder_stat.stat.isdir
+
+- name: Recreate 'config' as link
+  file:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/config"
+    src: "/etc/talend/{{ rpm_folder }}"
+    state: link
+  when: tdp_config_folder_stat.stat.exists and tdp_config_folder_stat.stat.isdir
+
+# Update systemd descriptor
+- name: Update systemd descriptor file for TDP
+  replace:
+    path: "/etc/systemd/system/{{ app_service }}.service"
+    regexp: "/opt/talend/"
+    replace: "{{ install_prefix }}/"
+
+- name: Reload changes in systemd descriptor file
+  shell: "systemctl daemon-reload"
+  args:
+    warn: no
+  changed_when: false


### PR DESCRIPTION
This fixes the installation of 4 roles mentioned above in the case is installation was done to a non-default folder.