### PR TITLE
TINSTL-1960 - updated code to reflect changes in RPMs

### DIFF
--- a/ansible/roles/sjs/tasks/patch.yml
+++ b/ansible/roles/sjs/tasks/patch.yml
@@ -25,12 +25,14 @@
 
 # Update systemd descriptor
 - name: Update systemd descriptor file for SJS
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
   replace:
     path: "/etc/systemd/system/{{ app_service }}.service"
     regexp: "/opt/talend/"
     replace: "{{ install_prefix }}/"
 
 - name: Reload changes in systemd descriptor file
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
   shell: "systemctl daemon-reload"
   args:
     warn: no

--- a/ansible/roles/sjs/tasks/patch.yml
+++ b/ansible/roles/sjs/tasks/patch.yml
@@ -14,7 +14,7 @@
   file:
     path: "{{ install_prefix }}/{{ rpm_folder }}/bin/settings.sh"
     state: absent
-  when: sjs_config_file_stat.stat.exists and not sjs_config_file_stat.stat.islink
+  when: sjs_config_file_stat.stat.exists and not sjs_config_file_stat.stat.islnk
 
 - name: Recreate 'settings.sh' as link
   file:

--- a/ansible/roles/sjs/tasks/patch.yml
+++ b/ansible/roles/sjs/tasks/patch.yml
@@ -21,18 +21,18 @@
     path: "{{ install_prefix }}/{{ rpm_folder }}/bin/settings.sh"
     src: "/etc/talend/{{ rpm_folder }}/settings.sh"
     state: link
-  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islnk
 
 # Update systemd descriptor
 - name: Update systemd descriptor file for SJS
-  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islnk
   replace:
     path: "/etc/systemd/system/{{ app_service }}.service"
     regexp: "/opt/talend/"
     replace: "{{ install_prefix }}/"
 
 - name: Reload changes in systemd descriptor file
-  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islink
+  when: not sjs_config_file_stat.stat.exists or not sjs_config_file_stat.stat.islnk
   shell: "systemctl daemon-reload"
   args:
     warn: no

--- a/ansible/roles/streamsrunner/README.md
+++ b/ansible/roles/streamsrunner/README.md
@@ -4,6 +4,8 @@ This role installs **Talend Streamsrunner**.
 
 Make sure you have completed the requirements listed in the [Root README](../../../README.md) file.
 
+**Attention:** Talend Streamsrunner RPM requires Java 8 (Oracle Java or OpenJDK). It will **not** work with Java 11.
+
 ## Role variables
 
 Before running the script, you can change the following variables in the *defaults/main.yml* file:

--- a/ansible/roles/streamsrunner/tasks/patch.yml
+++ b/ansible/roles/streamsrunner/tasks/patch.yml
@@ -25,12 +25,14 @@
 
 # Update systemd descriptor
 - name: Update systemd descriptor file for StreamsRunner
+  when: str_conf_folder_stat.stat.exists and str_conf_folder_stat.stat.isdir
   replace:
     path: "/etc/systemd/system/{{ app_service }}.service"
     regexp: "/opt/talend/"
     replace: "{{ install_prefix }}/"
 
 - name: Reload changes in systemd descriptor file
+  when: str_conf_folder_stat.stat.exists and str_conf_folder_stat.stat.isdir
   shell: "systemctl daemon-reload"
   args:
     warn: no

--- a/ansible/roles/tcomp/tasks/patch.yml
+++ b/ansible/roles/tcomp/tasks/patch.yml
@@ -25,12 +25,14 @@
 
 # Update systemd descriptor
 - name: Update systemd descriptor file for TCOMP
+  when: tcomp_config_folder_stat.stat.exists and tcomp_config_folder_stat.stat.isdir
   replace:
     path: "/etc/systemd/system/{{ app_service }}.service"
     regexp: "/opt/talend/"
     replace: "{{ install_prefix }}/"
 
 - name: Reload changes in systemd descriptor file
+  when: tcomp_config_folder_stat.stat.exists and tcomp_config_folder_stat.stat.isdir
   shell: "systemctl daemon-reload"
   args:
     warn: no

--- a/ansible/roles/tdp/tasks/patch.yml
+++ b/ansible/roles/tdp/tasks/patch.yml
@@ -4,6 +4,7 @@
 # There are 2 issues:
 #   1. 'config' folder is empty - it must point on /etc/talend/tdp
 #   2. systemd descriptor contains hard-coded /opt/talend
+# As these issues are fixed in 7.3.1, we will apply this patch only if old configuration is detected (7.1.1/7.2.1)
 
 - name: Get status of 'config' folder
   stat:
@@ -25,12 +26,14 @@
 
 # Update systemd descriptor
 - name: Update systemd descriptor file for TDP
+  when: tdp_config_folder_stat.stat.exists and tdp_config_folder_stat.stat.isdir
   replace:
     path: "/etc/systemd/system/{{ app_service }}.service"
     regexp: "/opt/talend/"
     replace: "{{ install_prefix }}/"
 
 - name: Reload changes in systemd descriptor file
+  when: tdp_config_folder_stat.stat.exists and tdp_config_folder_stat.stat.isdir
   shell: "systemctl daemon-reload"
   args:
     warn: no


### PR DESCRIPTION
In 7.2.1, we had a potential installation issue with TDP RPMs (TDP, SJS, TCOMP and StreamsRunner) - when installing into a non-default folder (not in /opt/talend), then system services would not work.
The fix for this was added to ansible scripts in 7.2.1.
Now, these 4 RPMs are fixed, and ansible code needs to be updated to avoid applying these changes if they are already fixed on RPM side.
Also we have found that StreamsRunner works only with Java 8 (not with Java 11), so this was also added to its readme.