### PR TITLE
TINSTL-2074 - fix for missing var update

### DIFF
--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -276,8 +276,8 @@
       regexp: "dataquality.semantic.update.enable=.*"
       replace: "dataquality.semantic.update.enable={{ tdp_dataquality_semantic_update_enable }}"
 
-- name: Modify Data Preparation dataquality semantic update enable for 7.2
-  when: rpm_base_version == 7.2
+- name: Modify Data Preparation dataquality semantic update enable for 7.2 / 7.3
+  when: rpm_base_version != 7.1
   replace:
       path: "/etc/talend/tdp/application.properties"
       regexp: "tsd.consumer.enabled=.*"


### PR DESCRIPTION
The parameter 'tdp_dataquality_semantic_update_enable' was ignored for RPM version 7.3 (only handled for 7.1 and 7.2 versions).
This PR fixes this issue.