### PR TITLE
TINSTL-2148 - Tomcat installation failed with non-default folder

### DIFF
--- a/ansible/roles/tac/tasks/main.yml
+++ b/ansible/roles/tac/tasks/main.yml
@@ -31,3 +31,4 @@
 
 # Install license
 - import_tasks: install_license.yml
+  when: rpm_base_version > 7.1

--- a/ansible/roles/tomcat/defaults/main.yml
+++ b/ansible/roles/tomcat/defaults/main.yml
@@ -8,4 +8,4 @@ rpm_name: "talend-tomcat"
 # The talend-tomcat package does not use the same versioning as other
 # Talend packages, thus must be specified
 
-tomcat_rpm_pkg_version: 9.0.10-1
+tomcat_rpm_pkg_version: "{{ '9.0.10-1' if rpm_base_version == 7.1 or rpm_base_version == 7.2 else '9.0.30-1' }}"


### PR DESCRIPTION
Fixes the issue with installation into non-default folder (not in /opt/talend). In that case, direct RPM link was used with full file name, and tomcat version is different between 7.1/7.2 and 7.3 (but the corresponding file was still keeping the original version from 7.1/7.2, this caused the fatal error during installation).
Also fixed a small issue with Install TAC license - this approach is not working in 7.1 (only works starting from 7.2 and above).