### PR TITLE
TINSTL-2164 - Access denied on Data Preparation screen

### DIFF
--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -83,7 +83,10 @@ tdp_security_oauth2_client_clientId: "64xIVPxviKWSog"
 tdp_security_oauth2_client_clientSecret: "9C0zCjp8yS-eZBqEi-KhBQ"
 tdp_security_oidc_client_claimIssueAtTolerance: "120"
 tdp_security_oauth2_resource_tokenInfoUri: "${iam.uri}/oidc/oauth2/introspect"
-tdp_security_oauth2_resource_uri: "{{'/api/**,/folders/**,/datasets/**,/preparations/**,/transform/**,/version/**,/acl/**,/apply/**,/export,/export/**,/aggregate,/sampling/**,/receivers/**,/error,/docs,/datastores/**,/preparation/**,/actions/**,/suggest/**,/dictionary/**' if  rpm_base_version == 7.1 else '/api/**,/folders/**,/datasets/**,/dataset/**,/preparations/**,/transform/**,/version/**,/acl/**,/apply/**,/export,/export/**,/aggregate,/sampling/**,/receivers/**,/error,/docs,/datastores/**,/preparation/**,/actions/**,/suggest/**,/dictionary/**,/transformation/preparations/**,/transformation/v2/**'}}"
+
+# Set tdp_security_oauth2_resource_uri ONLY if you are know what you are doing ! Otherwise it will use the default setting from RPM/zip
+tdp_security_oauth2_resource_uri: ""
+
 tdp_security_oauth2_resource_filter_order: "3"
 tdp_security_scim_enabled: "true"
 tdp_security_oauth2_client_access_token_uri: "${iam.uri}/oidc/oauth2/token"

--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -382,6 +382,7 @@
       replace: "security.oauth2.resource.tokenInfoUri={{ tdp_security_oauth2_resource_tokenInfoUri }}"
 
 - name: Modify Data Preparation security oauth2 resource uri
+  when: tdp_security_oauth2_resource_uri
   replace:
       path: "/etc/talend/tdp/application.properties"
       regexp: "security.oauth2.resource.uri=.*"


### PR DESCRIPTION
The correct value for "security.oauth2.resource.uri" already comes with installation package, so we should not update it without extra need.
The current approach was that we set this value, but it is different for 7.1, 7.2, 7.3 and 7.4 (and also the value line is too big), so it has no sense to set it up additionally when it already comes in the correct way.