### PR TITLE
Add Minio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following roles install third-party components:
 | [mongodb](ansible/roles/mongodb) | MongoDB server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                                   |
 | [kafka](ansible/roles/kafka)     | Apache Kafka server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                              |
 | [nexus](ansible/roles/nexus)     | Nexus Repository Manager                                                                                                                    |
-| [minio](ansible/roles/minio)     | MinIO server (required by [tsd](ansible/roles/tsd), [tds](ansible/roles/tds), [tdp](ansible/roles/tdp) )                                    |
+| [minio](ansible/roles/minio)     | MinIO server (required by [tsd](ansible/roles/tsd), [tds](ansible/roles/tds), [tdp](ansible/roles/tdp))                                    |
 
 ## List of applications compatible with Talend Cloud Hybrid setup
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following roles install third-party components:
 | [mongodb](ansible/roles/mongodb) | MongoDB server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                                   |
 | [kafka](ansible/roles/kafka)     | Apache Kafka server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                              |
 | [nexus](ansible/roles/nexus)     | Nexus Repository Manager                                                                                                                    |
+| [minio](ansible/roles/minio)     | MinIO server (required by [tsd](ansible/roles/tsd), [tds](ansible/roles/tds), [tdp](ansible/roles/tdp)                                      |
 
 ## List of applications compatible with Talend Cloud Hybrid setup
 
@@ -144,10 +145,11 @@ Each application requires some TCP/IP ports to be open by default:
 * tdq: 8187
 * logserver: 9200 and 9300 for Elastic Search; 5601 for Kibana; 5044, 8057 and 9600 for LogStash.
 
-In addition, service components (Kafka and MongoDB) require open ports when accessed from other hosts:
+In addition, service components (Kafka, MongoDB and Minio) require open ports when accessed from other hosts:
 
 * kafka: 2181, 9092
 * mongodb: 27017
+* minio: 9000
 
 To open a port, you can use one of the methods described below:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Each application requires some TCP/IP ports to be open by default:
 * nexus: 8081
 * iam: 9080
 * mdm: 8180
-* mwfl: 8280
 * runtime: 1099, 8000, 8001, 8040, 8101, 8555, 8888, 9001, 44444
 * jobserver: 8000, 8001, 8555, 8888
 * tdp: 9999

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The following roles install third-party components:
 | [mongodb](ansible/roles/mongodb) | MongoDB server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                                   |
 | [kafka](ansible/roles/kafka)     | Apache Kafka server (required by [tds](ansible/roles/tds), [tdp](ansible/roles/tdp), [tsd](ansible/roles/tsd))                              |
 | [nexus](ansible/roles/nexus)     | Nexus Repository Manager                                                                                                                    |
-| [minio](ansible/roles/minio)     | MinIO server (required by [tsd](ansible/roles/tsd), [tds](ansible/roles/tds), [tdp](ansible/roles/tdp)                                      |
+| [minio](ansible/roles/minio)     | MinIO server (required by [tsd](ansible/roles/tsd), [tds](ansible/roles/tds), [tdp](ansible/roles/tdp) )                                    |
 
 ## List of applications compatible with Talend Cloud Hybrid setup
 

--- a/ansible/roles/mdm/tasks/params_validation.yml
+++ b/ansible/roles/mdm/tasks/params_validation.yml
@@ -2,7 +2,7 @@
 # This script performs different parameters validation
 
 ######################################
-# MDM-specific parameters validation
+# MDM-specific parameter validation
 ######################################
 
 - name: Show error about wrong value for parameter mdm_use_audit

--- a/ansible/roles/minio/README.md
+++ b/ansible/roles/minio/README.md
@@ -22,7 +22,7 @@ Before running the script, you can change the following variables in the *defaul
 | --------------------- | --------------------------------------- | ------------------------------- |
 | `app_install_systemd` | Whether to install as a systemd service | Supported values: `yes` or `no` |
 
-### MongoDB port
+### Minio port
 
 | Parameter      | Description                        | Value                  |
 | -------------- | ---------------------------------- | ---------------------- |
@@ -54,7 +54,10 @@ Before running the script, you can change the following variables in the *defaul
     - java
     - talend-repo
     - tomcat
+    - kafka
     - mongodb
     - minio
+    - tsd
     - tds
+    - tdp
 ```

--- a/ansible/roles/minio/README.md
+++ b/ansible/roles/minio/README.md
@@ -1,0 +1,60 @@
+# MinIO
+
+This role installs **MinIO local server** (needed by tds, tsd and tdp roles).
+
+Make sure you have completed the requirements listed in the [Root README](../../../README.md) file.
+
+## Role variables
+
+Before running the script, you can change the following variables in the *defaults/main.yml* file:
+
+> **Note**: You can find details about each application installed using these Ansible roles in the corresponding RPM documentation on [Talend Help Center](https://help.talend.com/search/all?query=rpm&content-lang=en-US).
+
+### MinIO RPM version
+
+| Parameter               | Description         | Value                         |
+| ----------------------- | ------------------- | ----------------------------- |
+| `minio_pkg_version` | Minio RPM version   | Example: `{{ rpm_version }}-1` |
+
+### Systemd
+
+| Parameter             | Description                             | Value                           |
+| --------------------- | --------------------------------------- | ------------------------------- |
+| `app_install_systemd` | Whether to install as a systemd service | Supported values: `yes` or `no` |
+
+### MongoDB port
+
+| Parameter      | Description                        | Value                  |
+| -------------- | ---------------------------------- | ---------------------- |
+| `minio_port` | TCP/IP port used by MinIO server | Default value: `9000` |
+
+### MinIO bucket name
+
+| Parameter                  | Description                          | Value                           |
+| -------------------------- | ------------------------------------ | ------------------------------- |
+| `minio_bucket` | The name of bucket to be used | Default value: `default-bucket` |
+
+### AccessKey, SecretKey and Region
+
+| Parameter             | Description                               | Value                                 |
+| ----------------------| ----------------------------------------- | ------------------------------------- |
+| `minio_accesskey` | The Access Key to be used by MinIO server | Default: `usr7xJ0agsFq`            |
+| `minio_secretkey` | The Secret Key to be used by MinIO server | Default: `pwd9jYF26Van`            |
+| `minio_region`     | Region to be used by MinIO server         | Use only default value: `us-east-1` |
+
+> **Note**: If you update any of these values from defaults, then you will need to update also AWS S3 values in tds, tsd and tdp roles
+
+
+## Example playbook
+
+```yaml
+- hosts: tds-host
+  become: yes
+  roles:
+    - java
+    - talend-repo
+    - tomcat
+    - mongodb
+    - minio
+    - tds
+```

--- a/ansible/roles/minio/README.md
+++ b/ansible/roles/minio/README.md
@@ -1,8 +1,8 @@
 # MinIO
 
-This role installs **MinIO local server** (needed by tds, tsd and tdp roles).
+This role installs **MinIO local server** (required by roles tds, tsd and tdp).
 
-Make sure you have completed the requirements listed in the [Root README](../../../README.md) file.
+Make sure you have completed the requirements listed in the [root README](../../../README.md) file.
 
 ## Role variables
 
@@ -12,9 +12,9 @@ Before running the script, you can change the following variables in the *defaul
 
 ### MinIO RPM version
 
-| Parameter               | Description         | Value                         |
-| ----------------------- | ------------------- | ----------------------------- |
-| `minio_pkg_version` | Minio RPM version   | Example: `{{ rpm_version }}-1` |
+| Parameter           | Description       | Value                          |
+| ------------------- | ----------------- | ------------------------------ |
+| `minio_pkg_version` | Minio RPM version | Example: `{{ rpm_version }}-1` |
 
 ### Systemd
 
@@ -24,26 +24,25 @@ Before running the script, you can change the following variables in the *defaul
 
 ### Minio port
 
-| Parameter      | Description                        | Value                  |
-| -------------- | ---------------------------------- | ---------------------- |
-| `minio_port` | TCP/IP port used by MinIO server | Default value: `9000` |
+| Parameter    | Description                          | Value                 |
+| ------------ | ------------------------------------ | --------------------- |
+| `minio_port` | TCP/IP port used by the MinIO server | Default value: `9000` |
 
 ### MinIO bucket name
 
-| Parameter                  | Description                          | Value                           |
-| -------------------------- | ------------------------------------ | ------------------------------- |
-| `minio_bucket` | The name of bucket to be used | Default value: `default-bucket` |
+| Parameter      | Description               | Value                           |
+| -------------- | ------------------------- | ------------------------------- |
+| `minio_bucket` | Name of bucket to be used | Default value: `default-bucket` |
 
 ### AccessKey, SecretKey and Region
 
-| Parameter             | Description                               | Value                                 |
-| ----------------------| ----------------------------------------- | ------------------------------------- |
-| `minio_accesskey` | The Access Key to be used by MinIO server | Default: `usr7xJ0agsFq`            |
-| `minio_secretkey` | The Secret Key to be used by MinIO server | Default: `pwd9jYF26Van`            |
-| `minio_region`     | Region to be used by MinIO server         | Use only default value: `us-east-1` |
+| Parameter         | Description                                   | Value                                   |
+| ----------------- | --------------------------------------------- | --------------------------------------- |
+| `minio_accesskey` | The Access Key to be used by the MinIO server | Default: `usr7xJ0agsFq`                 |
+| `minio_secretkey` | The Secret Key to be used by the MinIO server | Default: `pwd9jYF26Van`                 |
+| `minio_region`    | Region to be used by the MinIO server         | Use only the default value: `us-east-1` |
 
 > **Note**: If you update any of these values from defaults, then you will need to update also AWS S3 values in tds, tsd and tdp roles
-
 
 ## Example playbook
 

--- a/ansible/roles/minio/README.md
+++ b/ansible/roles/minio/README.md
@@ -44,7 +44,6 @@ Before running the script, you can change the following variables in the *defaul
 
 > **Note**: If you update any of these values from defaults, then you will need to update also AWS S3 values in tds, tsd and tdp roles
 
-
 ## Example playbook
 
 ```yaml

--- a/ansible/roles/minio/README.md
+++ b/ansible/roles/minio/README.md
@@ -44,6 +44,7 @@ Before running the script, you can change the following variables in the *defaul
 
 > **Note**: If you update any of these values from defaults, then you will need to update also AWS S3 values in tds, tsd and tdp roles
 
+
 ## Example playbook
 
 ```yaml

--- a/ansible/roles/minio/defaults/main.yml
+++ b/ansible/roles/minio/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+# app_name, rpm_name and rpm_folder are standard variables, must be redefined for each role
+# it allows re-usage of tasks
+
+app_name: "Talend MinIO"
+rpm_name: "talend-minio"
+rpm_folder: "minio"
+app_service: "talend-minio"
+
+# Variable (RPM version) for Minio RPM
+minio_pkg_version: "{{ rpm_version }}-1"
+
+#####
+# Installation as systemd service
+#####
+app_install_systemd: "yes" # allowed values "yes" and "no"
+
+#
+# MinIO-specific properties
+# Attention: if anything is changed from default, then update also TDS, TDP and TSD variables)
+#
+
+# TCP/IP port used by MinIO server
+minio_port: 9000
+
+# Bucket
+minio_bucket: "default-bucket"
+
+# AccessKey, SecretKey and Region
+minio_accesskey: "usr7xJ0agsFq"
+minio_secretkey: "pwd9jYF26Van"
+minio_region:    "us-east-1"

--- a/ansible/roles/minio/defaults/main.yml
+++ b/ansible/roles/minio/defaults/main.yml
@@ -17,7 +17,7 @@ app_install_systemd: "yes" # allowed values "yes" and "no"
 
 #
 # MinIO-specific properties
-# Attention: if anything is changed from default, then update also TDS, TDP and TSD variables)
+# Attention: if anything is changed from default, then update also TDS, TDP and TSD variables
 #
 
 # TCP/IP port used by MinIO server

--- a/ansible/roles/minio/defaults/main.yml
+++ b/ansible/roles/minio/defaults/main.yml
@@ -17,7 +17,7 @@ app_install_systemd: "yes" # allowed values "yes" and "no"
 
 #
 # MinIO-specific properties
-# Attention: if anything is changed from default, then update also TDS, TDP and TSD variables
+# Attention: if anything is changed from default, then also update TDS, TDP and TSD variables
 #
 
 # TCP/IP port used by MinIO server
@@ -29,4 +29,4 @@ minio_bucket: "default-bucket"
 # AccessKey, SecretKey and Region
 minio_accesskey: "usr7xJ0agsFq"
 minio_secretkey: "pwd9jYF26Van"
-minio_region:    "us-east-1"
+minio_region: "us-east-1"

--- a/ansible/roles/minio/tasks/check_status.yml
+++ b/ansible/roles/minio/tasks/check_status.yml
@@ -1,0 +1,37 @@
+---
+
+# This common script checks the current status of application
+# If it is already installed, we should compare setting and throw error
+#    if actual settins are different
+# MinIO-specific: we cannot use common/tasks/check_status.yml, as MinIO RPM do not use install.params file
+
+- name: "Check whether {{ app_name }} RPM is installed"
+  command: "rpm -qa {{ rpm_name }}"
+  args:
+    warn: no
+  register: rpm_is_installed
+  changed_when: false
+
+- name: "Get actual installation prefix for {{ app_name }}"
+  when: rpm_is_installed.stdout != ''
+  shell: "set -o pipefail | rpm -ql {{ rpm_name }} | grep -v '/etc/talend/{{ rpm_folder }}' | head -n 1"
+  args:
+    warn: no
+  register: rpm_install_path
+  changed_when: false
+
+- name: "Show error if {{ app_name }} is already installed with a different prefix"
+  fail:
+    msg: "Error: {{ app_name }} is already installed with a different prefix ( {{ rpm_install_path.stdout }} )"
+  when: rpm_is_installed.stdout != '' and rpm_install_path.stdout != install_prefix
+
+- name: Check that installation is valid
+  when: rpm_is_installed.stdout != ''
+  stat:
+    path: "{{ install_prefix }}/{{ rpm_folder }}/bin/minio"
+  register: inst_params_status
+
+- name: "Show error about corrupted installation for {{ app_name }}"
+  fail:
+    msg: "Installation of {{ app_name }} is broken ! File server.properties is missing in {{ install_prefix }}/{{ rpm_folder }}/config"
+  when: rpm_is_installed.stdout != '' and not inst_params_status.stat.exists

--- a/ansible/roles/minio/tasks/check_status.yml
+++ b/ansible/roles/minio/tasks/check_status.yml
@@ -1,9 +1,8 @@
 ---
-
-# This common script checks the current status of application
-# If it is already installed, we should compare setting and throw error
-#    if actual settins are different
-# MinIO-specific: we cannot use common/tasks/check_status.yml, as MinIO RPM do not use install.params file
+# This common script checks the current status of the application
+# If it is already installed, we should compare settings and throw an error
+# if actual settings are different
+# MinIO-specific: we cannot use common/tasks/check_status.yml, as MinIO RPM does not use the install.params file
 
 - name: "Check whether {{ app_name }} RPM is installed"
   command: "rpm -qa {{ rpm_name }}"

--- a/ansible/roles/minio/tasks/install_rpm.yml
+++ b/ansible/roles/minio/tasks/install_rpm.yml
@@ -1,0 +1,43 @@
+---
+# This file handles installation with rpm (when non-default prefix is used)
+- name: "Check whether {{ app_name }} RPM is installed"
+  when: install_prefix != '/opt/talend'
+  command: "rpm -qa {{ rpm_name }}"
+  args:
+    warn: no
+  register: rpm_is_installed
+
+
+- name: "Get actual installation prefix for {{ app_name }}"
+  when: install_prefix != '/opt/talend' and rpm_is_installed.stdout != ''
+  shell: "set -o pipefail | rpm -ql {{ rpm_name }} | head -n 1"
+  args:
+    warn: no
+  register: rpm_install_path
+
+
+- name: "{{ app_name }} RPM is already installed with correct path"
+  when: install_prefix != '/opt/talend' and rpm_is_installed.stdout != '' and rpm_install_path.stdout == install_prefix
+  debug:
+    msg: "{{ app_name }} RPM is already installed"
+
+- name: "Check if {{ app_name }} RPM is already installed into other path"
+  fail:
+    msg: "FATAL: {{ app_name }} package is already installed with a different prefix {{ rpm_install_path.stdout }} !"
+  when: install_prefix != '/opt/talend' and rpm_is_installed.stdout != '' and rpm_install_path.stdout != install_prefix
+
+- name: "Install {{ app_name }} with rpm (non-default folder)"
+  when: install_prefix != '/opt/talend' and (rpm_is_installed.stdout == '' or rpm_install_path.stdout != install_prefix)
+  command: "rpm -i --prefix={{ install_prefix }} {{ rpm_repo_url }}/{{ rpm_name }}-{{ kafka_pkg_version }}.x86_64.rpm"
+  args:
+    warn: no
+  environment:
+    TALEND_INSTALL_USER: '{{ install_user }}'
+    TALEND_INSTALL_GROUP: '{{ install_group }}'
+    TALEND_INSTALL_SYSTEMD: "{{ '1' if app_install_systemd == 'yes' else '0' }}"
+    JAVA_HOME:              "{{ java_dir.stdout }}"
+    TALEND_MINIO_PORT:      "{{ minio_port }}"
+    TALEND_MINIO_BUCKET:    "{{ minio_bucket }}"
+    TALEND_MINIO_USER:      "{{ minio_accesskey }}"
+    TALEND_MINIO_PASS:      "{{ minio_secretkey }}"
+    TALEND_MINIO_REGION:    "{{ minio_region }}"

--- a/ansible/roles/minio/tasks/install_rpm.yml
+++ b/ansible/roles/minio/tasks/install_rpm.yml
@@ -28,7 +28,7 @@
 
 - name: "Install {{ app_name }} with rpm (non-default folder)"
   when: install_prefix != '/opt/talend' and (rpm_is_installed.stdout == '' or rpm_install_path.stdout != install_prefix)
-  command: "rpm -i --prefix={{ install_prefix }} {{ rpm_repo_url }}/{{ rpm_name }}-{{ kafka_pkg_version }}.x86_64.rpm"
+  command: "rpm -i --prefix={{ install_prefix }} {{ rpm_repo_url }}/{{ rpm_name }}-{{ minio_pkg_version }}.x86_64.rpm"
   args:
     warn: no
   environment:

--- a/ansible/roles/minio/tasks/install_yum.yml
+++ b/ansible/roles/minio/tasks/install_yum.yml
@@ -1,0 +1,17 @@
+---
+# This file handles installation with yum (to default folder /opt/talend)
+#
+- name: "Install {{ app_name }} with yum"
+  yum:
+    name: "{{ rpm_name }}"
+    state: present
+  environment:
+    TALEND_INSTALL_USER: '{{ install_user }}'
+    TALEND_INSTALL_GROUP: '{{ install_group }}'
+    TALEND_INSTALL_SYSTEMD: "{{ '1' if app_install_systemd == 'yes' else '0' }}"
+    JAVA_HOME:              "{{ java_dir.stdout }}"
+    TALEND_MINIO_PORT:      "{{ minio_port }}"
+    TALEND_MINIO_BUCKET:    "{{ minio_bucket }}"
+    TALEND_MINIO_USER:      "{{ minio_accesskey }}"
+    TALEND_MINIO_PASS:      "{{ minio_secretkey }}"
+    TALEND_MINIO_REGION:    "{{ minio_region }}"

--- a/ansible/roles/minio/tasks/main.yml
+++ b/ansible/roles/minio/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Check params to be correct
+- import_tasks: params_validation.yml
+
+# Check systemd params to be correct
+- include_tasks: ../../common/tasks/params_validation_extra.yml
+
+# Check situation with current status (e.g. installed but into different path - that would be an error)
+- include_tasks: check_status.yml
+
+# Stop systemd service (if it exists, as it might not exist on a new installation)
+#   We need this to update configuration
+- include_tasks: ../../common/tasks/stop_service.yml
+
+# We will include installation with yum or with rpm depending of prefix used
+- include_tasks: install_yum.yml
+  when: install_prefix == '/opt/talend'
+
+- include_tasks: install_rpm.yml
+  when: install_prefix != '/opt/talend'
+
+# Update configuration
+- import_tasks: update_config.yml
+
+# Starting systemd service
+- include_tasks: ../../common/tasks/start_service.yml

--- a/ansible/roles/minio/tasks/params_validation.yml
+++ b/ansible/roles/minio/tasks/params_validation.yml
@@ -1,0 +1,26 @@
+---
+# This script performs different parameters validation
+
+######################################
+# MDM-specific parameters validation
+######################################
+
+# Check port-type parameter: zook_clientPort
+- name: Check port-type parameters
+  fail:
+    msg: "Parameter {{ item.name }} has value {{ item.value }}, which is not a valid TCP/IP port number !"
+  when: not ( item.value | string | regex_search( '[0-9]*' ) ) or ( item.value | int < 0 ) or ( item.value | int > 65535 )
+  with_items:
+    - { name: "minio_port", value: "{{ minio_port }}" }
+
+# Check buket name
+- name: Check bucket name
+  fail:
+    msg: "Parameter minio_bucket is not valid, use only alphanumeric value plus dot and dash !"
+  when: not ( minio_bucket | string | regex_search( '[0-9a-zA-Z.-]*' ) )
+
+
+- name: Show error if accesskey or secretkey or region is empty
+  fail:
+    msg: Any of parameter "minio_accesskey", "minio_secretkey" or "minio_region" cannot be empty !
+  when: minio_accesskey == "" or minio_secretkey == "" or minio_region == ""

--- a/ansible/roles/minio/tasks/params_validation.yml
+++ b/ansible/roles/minio/tasks/params_validation.yml
@@ -24,3 +24,8 @@
   fail:
     msg: Any of parameter "minio_accesskey", "minio_secretkey" or "minio_region" cannot be empty !
   when: minio_accesskey == "" or minio_secretkey == "" or minio_region == ""
+
+- name: Show error when used with RPM 7.3 or less
+  fail:
+    msg: MinIO role can be used only with version 7.4 or above
+  when: rpm_base_version <= 7.3

--- a/ansible/roles/minio/tasks/params_validation.yml
+++ b/ansible/roles/minio/tasks/params_validation.yml
@@ -2,7 +2,7 @@
 # This script performs different parameters validation
 
 ######################################
-# MDM-specific parameters validation
+# MDM-specific parameter validation
 ######################################
 
 # Check port-type parameter: zook_clientPort
@@ -19,13 +19,12 @@
     msg: "Parameter minio_bucket is not valid, use only alphanumeric value plus dot and dash !"
   when: not ( minio_bucket | string | regex_search( '[0-9a-zA-Z.-]*' ) )
 
-
 - name: Show error if accesskey or secretkey or region is empty
   fail:
     msg: Any of parameter "minio_accesskey", "minio_secretkey" or "minio_region" cannot be empty !
   when: minio_accesskey == "" or minio_secretkey == "" or minio_region == ""
 
-- name: Show error when used with RPM 7.3 or less
+- name: Show error when used with RPM 7.3 or lower
   fail:
     msg: MinIO role can be used only with version 8.0 or above
   when: rpm_base_version <= 7.3

--- a/ansible/roles/minio/tasks/params_validation.yml
+++ b/ansible/roles/minio/tasks/params_validation.yml
@@ -27,5 +27,5 @@
 
 - name: Show error when used with RPM 7.3 or less
   fail:
-    msg: MinIO role can be used only with version 7.4 or above
+    msg: MinIO role can be used only with version 8.0 or above
   when: rpm_base_version <= 7.3

--- a/ansible/roles/minio/tasks/update_config.yml
+++ b/ansible/roles/minio/tasks/update_config.yml
@@ -1,0 +1,38 @@
+---
+
+# This script used for updating current application parameters if the application is already installed
+# It can be run just after the installation or after some time (re-configuration)
+# Some parameters cannot be re-configured (installation path, user, group, systemd status)
+# All other parameters must be reconfigured here
+
+# Input params:
+#   - install_prefix - (defined in group_vars/all)
+#
+# All other parameters are from "roles/minio/defaults/main.yml"
+#
+# There is no configuration file for MinIO RPM and instead all parameters are stored in minio/start.sh script
+
+# Updating TCP-IP port
+- name: Update MinIO tcp-ip port
+  replace:
+    path: "{{ install_prefix }}/minio/start.sh"
+    regexp:  '--address :(\d)+'
+    replace: '--address :{{ minio_port }}'
+
+- name: Update MinIO access key
+  replace:
+    path: "{{ install_prefix }}/minio/start.sh"
+    regexp:  '^MINIO_ACCESS_KEY=.*'
+    replace: 'MINIO_ACCESS_KEY={{ minio_accesskey }}'
+
+- name: Update MinIO secret key
+  replace:
+    path: "{{ install_prefix }}/minio/start.sh"
+    regexp:  '^MINIO_SECRET_KEY=.*'
+    replace: 'MINIO_SECRET={{ minio_secretkey }}'
+
+- name: Update MinIO region
+  replace:
+    path: "{{ install_prefix }}/minio/start.sh"
+    regexp:  '^MINIO_REGION=.*'
+    replace: 'MINIO_REGION={{ minio_region }}'

--- a/ansible/roles/minio/tasks/update_config.yml
+++ b/ansible/roles/minio/tasks/update_config.yml
@@ -15,24 +15,24 @@
 # Updating TCP-IP port
 - name: Update MinIO tcp-ip port
   replace:
-    path: "{{ install_prefix }}/minio/start.sh"
+    path: "{{ install_prefix }}/minio/start_minio.sh"
     regexp:  '--address :(\d)+'
     replace: '--address :{{ minio_port }}'
 
 - name: Update MinIO access key
   replace:
-    path: "{{ install_prefix }}/minio/start.sh"
+    path: "{{ install_prefix }}/minio/start_minio.sh"
     regexp:  '^MINIO_ACCESS_KEY=.*'
     replace: 'MINIO_ACCESS_KEY={{ minio_accesskey }}'
 
 - name: Update MinIO secret key
   replace:
-    path: "{{ install_prefix }}/minio/start.sh"
+    path: "{{ install_prefix }}/minio/start_minio.sh"
     regexp:  '^MINIO_SECRET_KEY=.*'
     replace: 'MINIO_SECRET={{ minio_secretkey }}'
 
 - name: Update MinIO region
   replace:
-    path: "{{ install_prefix }}/minio/start.sh"
+    path: "{{ install_prefix }}/minio/start_minio.sh"
     regexp:  '^MINIO_REGION=.*'
     replace: 'MINIO_REGION={{ minio_region }}'

--- a/ansible/roles/minio/tasks/update_config.yml
+++ b/ansible/roles/minio/tasks/update_config.yml
@@ -10,7 +10,7 @@
 #
 # All other parameters are from "roles/minio/defaults/main.yml"
 #
-# There is no configuration file for MinIO RPM and instead all parameters are stored in minio/start.sh script
+# There is no configuration file for MinIO RPM and instead all parameters are stored in minio/start_minio.sh script
 
 # Updating TCP-IP port
 - name: Update MinIO tcp-ip port

--- a/ansible/roles/tac/tasks/update_config_installed.yml
+++ b/ansible/roles/tac/tasks/update_config_installed.yml
@@ -59,7 +59,7 @@
   replace:
     path: "{{ tac_config_location }}/configuration.properties"
     regexp:  '^database\.url=.*'
-    replace: "database.url=jdbc:h2:{0}/WEB-INF/database/talend_administrator;MV_STORE=FALSE;MVCC=TRUE;AUTO_SERVER=TRUE;lock_timeout=15000"
+    replace: "database.url=jdbc:h2:{0}/WEB-INF/database/talend_administrator;MV_STORE=FALSE;AUTO_SERVER=TRUE;lock_timeout=15000;DEFAULT_LOCK_TIMEOUT=15000;LOCK_MODE=0"
 
 - name: Update DB Driver for H2 database
   when: tac_database == "h2"

--- a/ansible/roles/tdp/README.md
+++ b/ansible/roles/tdp/README.md
@@ -317,6 +317,21 @@ Apache Spark is a fast and general-purpose cluster computing system. It provides
 
 More information about Spark configuration properties can be found at https://spark.apache.org/docs/1.6.2/configuration.html
 
+## Connection to AWS S3
+
+**Talend Data Preparation** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+
+The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+
+| Parameter      | Description        | Default value                                                    |
+|----------------|--------------------|------------------------------------------------------------------|
+| tdp_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
+| tdp_s3bucket   | Bucket name        | `default-bucket`                                                 |
+| tdp_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
+| tdp_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
+| tdp_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
+| tdp_basepath   | The base path      | *(empty value)*                                                  |
+
 ## Dependencies
 
 The following roles must be used to successfully install and deploy Talend Data Preparation:

--- a/ansible/roles/tdp/README.md
+++ b/ansible/roles/tdp/README.md
@@ -319,9 +319,10 @@ More information about Spark configuration properties can be found at https://sp
 
 ## Connection to AWS S3
 
-**Talend Data Preparation** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+**Talend Data Preparation** requires connection to Minio (or AWS S3) server to share semantic dictionary with **TSD**.
+If you do not have an existing Minio / AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
 
-The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:
 
 | Parameter      | Description        | Default value                                                    |
 |----------------|--------------------|------------------------------------------------------------------|

--- a/ansible/roles/tdp/README.md
+++ b/ansible/roles/tdp/README.md
@@ -27,9 +27,9 @@ Before running the script, you can change the following variables in the *defaul
 
 The following options increase network throughput and are activated by default:
 
-| Parameter                           | Description                                                             | Value                                        |
-| ----------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
-| `tdp_server_compression_enabled`    | Whether to enable compression of responses                              | Possible values: `true` (default) or `false` |
+| Parameter                           | Description                                                             | Value                                                                                                                                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tdp_server_compression_enabled`    | Whether to enable compression of responses                              | Possible values: `true` (default) or `false`                                                                                                                                           |
 | `tdp_server_compression_mime_types` | Comma-separated mime-types which are targets for compression operations | Default value: `text/plain,text/html,text/css,application/json,application/x-javascript,text/xml,application/xml,application/xml+rss,text/javascript,application/javascript,text/x-js` |
 
 ### Hybrid configuration
@@ -273,16 +273,16 @@ Do not modify the default settings of the following parameters unless instructed
 
 | Parameter                              | Description                                    | Value                                                                              |
 | -------------------------------------- | ---------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `tdp_async_runtime_contextPath`        | Runtime context path for async operations      | Default value: `/api`                                                                  |
+| `tdp_async_runtime_contextPath`        | Runtime context path for async operations      | Default value: `/api`                                                              |
 | `tdp_spring_mvc_async_request_timeout` | Timeout (in milliseconds) for async executions | Default value: `600000`<br/>This value may need to be increased for large datasets |
 
 ### Logging properties
 
 | Parameter                           | Description                                                                                                              | Value                                                                                                                                                                      |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `tdp_root_logger`                   | Logger name (SLF4J) prefix added to the event category                                                                   | Default value: `audit`                                                                                                                                                          |
+| `tdp_root_logger`                   | Logger name (SLF4J) prefix added to the event category                                                                   | Default value: `audit`                                                                                                                                                     |
 | `tdp_backend`                       | Logging backend. If set to `auto`, the audit library will try to detect and use the logging library is present           | Possible values: `auto`, `logback`, `log4j1`                                                                                                                               |
-| `tdp_encoding`                      | Encoding to use when writing events using appenders                                                                      | Default value: `UTF-8`                                                                                                                                                          |
+| `tdp_encoding`                      | Encoding to use when writing events using appenders                                                                      | Default value: `UTF-8`                                                                                                                                                     |
 | `tdp_application_name`              | Name of the application that logs audit events. This value will be put into MDC for each logged event                    | Default value: `Data Preparation`                                                                                                                                          |
 | `tdp_instance_name`                 | Name of the instance of the service. This value will be put into MDC for each logged event                               | Default value: `DefaultInstance`                                                                                                                                           |
 | `tdp_propagate_appender_exceptions` | Behaviour of API calls if one or more appenders could not process the event. *Only used in Data Preparation version 7.1* | Possible values: `all` (default), `none`                                                                                                                                   |
@@ -302,7 +302,7 @@ The file appender puts log entries into a JSON file. In most cases, there should
 
 | Parameter                 | Description                                   | Value                                        |
 | ------------------------- | --------------------------------------------- | -------------------------------------------- |
-| `tdp_appender_http_url`   | URL of target where logging data will be sent | Default value: `http://localhost:8057/`                            |
+| `tdp_appender_http_url`   | URL of target where logging data will be sent | Default value: `http://localhost:8057/`      |
 | `tdp_appender_http_async` | Whether to use asynchronous mode              | Possible values: `true` (default) or `false` |
 
 ### Spark properties
@@ -319,19 +319,19 @@ More information about Spark configuration properties can be found at https://sp
 
 ## Connection to Minio / AWS S3
 
-**Talend Data Preparation** requires connection to Minio (or AWS S3) server to share semantic dictionary with **TSD**.
-If you do not have an existing Minio / AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+**Talend Data Preparation** requires connection to a Minio server (or AWS S3) to share semantic dictionary with **TSD**.
+If you do not have an existing Minio / AWS S3 account, then an embedded Minio server (**minio** role) can be used instead.
 
 The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:
 
-| Parameter      | Description        | Default value                                                    |
-|----------------|--------------------|------------------------------------------------------------------|
-| tdp_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
-| tdp_s3bucket   | Bucket name        | `default-bucket`                                                 |
-| tdp_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
-| tdp_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
-| tdp_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
-| tdp_basepath   | The base path      | *(empty value)*                                                  |
+| Parameter      | Description        | Default value                                                   |
+| -------------- | ------------------ | --------------------------------------------------------------- |
+| tdp_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                         |
+| tdp_s3bucket   | Bucket name        | `default-bucket`                                                |
+| tdp_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role) |
+| tdp_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                  |
+| tdp_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                  |
+| tdp_basepath   | The base path      | *(empty value)*                                                 |
 
 ## Dependencies
 

--- a/ansible/roles/tdp/README.md
+++ b/ansible/roles/tdp/README.md
@@ -317,7 +317,7 @@ Apache Spark is a fast and general-purpose cluster computing system. It provides
 
 More information about Spark configuration properties can be found at https://spark.apache.org/docs/1.6.2/configuration.html
 
-## Connection to AWS S3
+## Connection to Minio / AWS S3
 
 **Talend Data Preparation** requires connection to Minio (or AWS S3) server to share semantic dictionary with **TSD**.
 If you do not have an existing Minio / AWS S3 account, then embedded Minio server (**minio** role) can be used instead.

--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -158,3 +158,13 @@ tdp_spark_executor_cores: "4"
 # Hybrid mode
 tdp_hybrid_mode:   "no"     # Can be "yes" or "no"
 tdp_hybrid_region: "us"     # Can be one of "us", "eu" or "ap"
+
+#####
+# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+#####
+tdp_s3endpoint: "http://localhost:9000"
+tdp_s3bucket:   "default-bucket"
+tdp_s3region:   "us-east-1"
+tdp_s3user:     "usr7xJ0agsFq"
+tdp_s3pass:     "pwd9jYF26Van"
+tdp_basepath:   ""

--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -160,7 +160,7 @@ tdp_hybrid_mode:   "no"     # Can be "yes" or "no"
 tdp_hybrid_region: "us"     # Can be one of "us", "eu" or "ap"
 
 #####
-# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
 #####
 tdp_s3endpoint: "http://localhost:9000"
 tdp_s3bucket:   "default-bucket"

--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -21,8 +21,8 @@ app_install_systemd: "yes" # allowed values "yes" and "no"
 tdp_public_ip: "localhost"
 tdp_server_port: "9999"
 
-tdp_iam_ip: "localhost"  # IAM host to be used (will be used only for non-hybrid configuration, otherwise ignored)
-tdp_iam_port: "9080"     # IAM port to be used (will be used only for non-hybrid configuration, otherwise ignored)
+tdp_iam_ip: "localhost" # IAM host to be used (will be used only for non-hybrid configuration, otherwise ignored)
+tdp_iam_port: "9080" # IAM port to be used (will be used only for non-hybrid configuration, otherwise ignored)
 
 tdp_async_runtime_contextPath: "/api"
 tdp_server_compression_enabled: "true"
@@ -101,7 +101,7 @@ tdp_security_oidc_client_endSessionEndpoint: "${iam.uri}/oidc/idp/logout"
 tdp_security_oidc_client_logoutSuccessUrl: "http://${public.ip}:${server.port}"
 tdp_security_oauth2_logout_uri: "/signOut"
 tdp_security_oauth2_sso_login_path: "/signIn"
-tdp_iam_scim_url: "http://${iam.ip}:{{ tdp_iam_port }}/scim/"  # (only for non-hybrid mode) 
+tdp_iam_scim_url: "http://${iam.ip}:{{ tdp_iam_port }}/scim/" # (only for non-hybrid mode)
 tdp_security_oauth2_resource_tokenInfoUriCache_enabled: "true"
 tdp_tenant_account_cache_enabled: "true"
 tdp_gateway_api_service_url: "http://${public.ip}:${server.port}"
@@ -130,7 +130,7 @@ tdp_logging_level_org_talend_dataprep_fullrun: "INFO"
 tdp_logging_level_org_talend_dataprep_api_dataquality: "INFO"
 tdp_logging_level_org_talend_dataprep_configuration: "INFO"
 tdp_logging_level_org_talend_dataquality_semantic: "INFO"
-tdp_audit_log_enabled: "true"       # (only for non-hybrid mode, otherwise always "false")
+tdp_audit_log_enabled: "true" # (only for non-hybrid mode, otherwise always "false")
 tdp_talend_logging_audit_config: "config/audit.properties"
 tdp_default_text_enclosure: '"'
 tdp_default_text_escape: '"'
@@ -156,15 +156,15 @@ tdp_spark_executor_instances: "10"
 tdp_spark_executor_cores: "4"
 
 # Hybrid mode
-tdp_hybrid_mode:   "no"     # Can be "yes" or "no"
-tdp_hybrid_region: "us"     # Can be one of "us", "eu" or "ap"
+tdp_hybrid_mode: "no" # Can be "yes" or "no"
+tdp_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
 
 #####
-# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
+# Communication with Minio / AWS S3 (defaults are set to use a local "minio" role)
 #####
 tdp_s3endpoint: "http://localhost:9000"
-tdp_s3bucket:   "default-bucket"
-tdp_s3region:   "us-east-1"
-tdp_s3user:     "usr7xJ0agsFq"
-tdp_s3pass:     "pwd9jYF26Van"
-tdp_basepath:   ""
+tdp_s3bucket: "default-bucket"
+tdp_s3region: "us-east-1"
+tdp_s3user: "usr7xJ0agsFq"
+tdp_s3pass: "pwd9jYF26Van"
+tdp_basepath: ""

--- a/ansible/roles/tdp/tasks/params_validation.yml
+++ b/ansible/roles/tdp/tasks/params_validation.yml
@@ -197,4 +197,4 @@
 - name: Check correct MinIO port (if MinIO is used)
   fail:
     msg: Incorrect value tdp_s3endpoint, port does not match with variable minio_port
-  when: minio_port is defined and tdp_s3endpoint | urlsplit('port') != minio_port
+  when: minio_port is defined and tdp_s3endpoint | urlsplit('port') != minio_port | int

--- a/ansible/roles/tdp/tasks/params_validation.yml
+++ b/ansible/roles/tdp/tasks/params_validation.yml
@@ -193,3 +193,8 @@
   fail:
     msg: Wrong value for parameter "tdp_hybrid_region", must be one of "us", "eu" or "ap"
   when: tdp_hybrid_region != "us" and tdp_hybrid_region != "eu" and tdp_hybrid_region != "ap"
+
+- name: Check correct MinIO port (if MinIO is used)
+  fail:
+    msg: Incorrect value tdp_s3endpoint, port does not match with variable minio_port
+  when: minio_port is defined and tdp_s3endpoint | urlsplit('port') != minio_port

--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -1023,8 +1023,8 @@
 - name: Update AWS S3 region
   replace:
     path: "/etc/talend/tdp/application.properties"
-    regexp:  '\.s3Repository\.password=.*'
-    replace: '.s3Repository.password={{ tdp_s3pass }}'
+    regexp:  '\.s3Repository\.s3\.region=.*'
+    replace: '.s3Repository.s3.region={{ tdp_s3region }}'
 
 - name: Update AWS S3 base path
   replace:

--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -994,3 +994,40 @@
       path: "/etc/talend/tdp/application.properties"
       regexp: 'security\.oidc\.client\.sessionManagementUri='
       line: "#security.oidc.client.sessionManagementUri=${iam.uri}/oidc/session-management"
+
+## AWS S3 communication
+- name: Update AWS S3 endpoint URL
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.s3\.endpoint=.*'
+    replace: '.s3Repository.s3.endpoint={{ tdp_s3endpoint }}'
+
+- name: Update AWS S3 bucket URL
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.bucket-url=.*'
+    replace: '.s3Repository.bucket-url=s3://{{ tdp_s3bucket }}'
+
+- name: Update AWS S3 username
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.username=.*'
+    replace: '.s3Repository.username={{ tdp_s3user }}'
+
+- name: Update AWS S3 password
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tdp_s3pass }}'
+
+- name: Update AWS S3 region
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tdp_s3pass }}'
+
+- name: Update AWS S3 base path
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp:  '\.s3Repository\.base-path=.*'
+    replace: '.s3Repository.base-path={{ tdp_basepath }}'

--- a/ansible/roles/tds/README.md
+++ b/ansible/roles/tds/README.md
@@ -45,20 +45,21 @@ The parameters with `First Install Only` as `Yes` can only be set at initial ins
 | `tds_oidc_id`                     | No                 | Talend Identity and Access Management OIDC client identifier.<br>For Hybrid mode: Client ID for your account (retrieved from Talend Management Console)  | `tl6K6ac7tSE-LQ`             |
 | `tds_oidc_secret`                 | No                 | Talend Identity and Access Management OIDC password.<br>For Hybrid mode: Client Secret for your account (retrieved from Talend Management Console)  | `sLbyFKTzM8F0dTL10mHd3A`     |
 
-## Connection to AWS S3
+## Connection to Minio / AWS S3
 
-**Talend Data Stewardship** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+**Talend Data Stewardship** requires connection to Minio (or AWS S3) server to share semantic dictionary with **TSD**.
+If you do not have an existing Minio / AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
 
-The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:
 
-| Parameter      | Description        | Default value                                                    |
-|----------------|--------------------|------------------------------------------------------------------|
-| tds_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
-| tds_s3bucket   | Bucket name        | `default-bucket`                                                 |
-| tds_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
-| tds_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
-| tds_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
-| tds_basepath   | The base path      | *(empty value)*                                                  |
+| Parameter      | Description         | Default value                                                    |
+|----------------|---------------------|------------------------------------------------------------------|
+| tds_s3endpoint | AWS S3 endpoint URL | `http://localhost:9000`                                          |
+| tds_s3bucket   | Bucket name         | `default-bucket`                                                 |
+| tds_s3region   | Used AWS S3 region  | `us-east-1` (do not change it if using embedded **minio** role)  |
+| tds_s3user     | AWS S3 access key   | `usr7xJ0agsFq`                                                   |
+| tds_s3pass     | AWS S3 secret key   | `pwd9jYF26Van`                                                   |
+| tds_basepath   | The base path       | *(empty value)*                                                  |
 
 ## Dependencies
 

--- a/ansible/roles/tds/README.md
+++ b/ansible/roles/tds/README.md
@@ -45,6 +45,21 @@ The parameters with `First Install Only` as `Yes` can only be set at initial ins
 | `tds_oidc_id`                     | No                 | Talend Identity and Access Management OIDC client identifier.<br>For Hybrid mode: Client ID for your account (retrieved from Talend Management Console)  | `tl6K6ac7tSE-LQ`             |
 | `tds_oidc_secret`                 | No                 | Talend Identity and Access Management OIDC password.<br>For Hybrid mode: Client Secret for your account (retrieved from Talend Management Console)  | `sLbyFKTzM8F0dTL10mHd3A`     |
 
+## Connection to AWS S3
+
+**Talend Data Stewardship** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+
+The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+
+| Parameter      | Description        | Default value                                                    |
+|----------------|--------------------|------------------------------------------------------------------|
+| tds_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
+| tds_s3bucket   | Bucket name        | `default-bucket`                                                 |
+| tds_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
+| tds_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
+| tds_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
+| tds_basepath   | The base path      | *(empty value)*                                                  |
+
 ## Dependencies
 
 The following roles must be used to successfully install TDS:

--- a/ansible/roles/tds/README.md
+++ b/ansible/roles/tds/README.md
@@ -13,53 +13,53 @@ Before running the script, you can change the following variables in the *defaul
 The following table lists the configurable parameters for the TDS playbook and their default values.
 The parameters with `First Install Only` as `Yes` can only be set at initial installation. Any subsequent changes to the values are not taken into account during an update.
 
-| Parameter                         | First Install Only | Description                                                                                                                | Default                      |
-| --------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `app_install_systemd`             | Yes                | Installation of the service in systemd: `yes` or `no`                                                                      | `yes`                        |
-| `app_use_talend_tomcat`           | Yes                | Use Talend Tomcat: `yes` or `no`                                                                                           | `yes`                        |
-| `app_tomcat_port`                 | Yes                | Port of Tomcat                                                                                                             | `19999`                      |
-| `app_tomcat_home`                 | Yes                | Path to Tomcat home (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`)                                       | `/opt/tomcat`                |
-| `app_tomcat_mode`                 | Yes                | Tomcat mode: `direct` or `shared` (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`)                         | `direct`                     |
-| `app_tomcat_setup`                | Yes                | Let RPM update customer's tomcat configuration like ports (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`) | `no`                         |
-| `tds_kafka_host`                  | No                 | Host of Kafka broker                                                                                                       | `localhost`                  |
-| `tds_kafka_port`                  | No                 | Port of Kafka broker                                                                                                       | `9092`                       |
-| `tds_mongo_host`                  | No                 | Host of MongoDB                                                                                                            | `localhost`                  |
-| `tds_mongo_port`                  | No                 | Port of MongoDB                                                                                                            | `27017`                      |
-| `tds_mongo_database`              | No                 | Name of the TDS MongoDB database                                                                                           | `tds`                        |
-| `tds_mongo_username`              | No                 | Username of the TDS MongoDB database                                                                                       | `tds-user`                   |
-| `tds_mongo_password`              | No                 | Password of the TDS MongoDB database. Default values for security settings must be changed                                 | `duser`                      |
-| `tds_audit_enabled`               | No                 | Enables the audit for TDS. This is taken into account only when `tds_hybrid_mode` = `no`. Possible values are `true` and `false`. | `true`                |
-| `tds_appender_http_url`           | No                 | URL for http log appender.                                                                                                 | `http://localhost:8057/`     |
-| `tds_security_scim_url`           | No                 | URL to Talend Identity and Access Management SCIM                                                                          | `http://localhost:9080/scim` |
-| `tds_security_oidc_url`           | No                 | URL to Talend Identity and Access Management                                                                               | `http://localhost:9080/oidc` |
-| `tds_security_oidc_user_auth_url` | No                 | URL to Talend Identity and Access Management User Authentication                                                           | `http://localhost:9080/oidc` |
-| `tds_use_semantic_dictionary`     | No                 | Enable link with Talend Dictionary Service: `yes` (only if you have a license) or `no`                                    | `yes`                        |
-| `tds_semantic_dictionary_url`     | No                 | URL of Talend Dictionary Service                                                                                         | `http://localhost:8187`      |
-| `tds_use_tdp_switch`              | No                 | Enable Talend Data Preparation app switch: `yes` (only if you have a license) or `no`                                      | no                           |
-| `tds_front_tdp_url`               | No                 | URL of Talend Data Preparation                                                                                             | `http://localhost:9999`      |
-| `tds_language`                    | No                 | Set the language. Supported values: `en-US` or `fr-FR` or `ja-JP` or `zh-CN`                                               | `en-US`                      |
-| `tds_hybrid_mode`                 | No                 | Installation of TDS in Hybrid mode. Available values are `yes` and `no`                                                    | `no`                         |
-| `tds_hybrid_region`               | No                 | Hybrid region location, can be one of `us`, `eu` or `ap`                                                                   | `us`                         |
-| `tds_hybrid_data_center`          | No                 | Hybrid data center to use, provider-specific notation (for AWS, can be `us-east-1`, `eu-central-1` or `ap-south-1`)        | `us-east-1`                  |
-| `tds_hybrid_cloud_provider`       | No                 | The cloud provider for Hybrid mode, can be either `AWS` or `azure`                                                         | `AWS`                        |
-| `tds_oidc_id`                     | No                 | Talend Identity and Access Management OIDC client identifier.<br>For Hybrid mode: Client ID for your account (retrieved from Talend Management Console)  | `tl6K6ac7tSE-LQ`             |
-| `tds_oidc_secret`                 | No                 | Talend Identity and Access Management OIDC password.<br>For Hybrid mode: Client Secret for your account (retrieved from Talend Management Console)  | `sLbyFKTzM8F0dTL10mHd3A`     |
+| Parameter                         | First Install Only | Description                                                                                                                                             | Default                      |
+| --------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `app_install_systemd`             | Yes                | Installation of the service in systemd: `yes` or `no`                                                                                                   | `yes`                        |
+| `app_use_talend_tomcat`           | Yes                | Use Talend Tomcat: `yes` or `no`                                                                                                                        | `yes`                        |
+| `app_tomcat_port`                 | Yes                | Port of Tomcat                                                                                                                                          | `19999`                      |
+| `app_tomcat_home`                 | Yes                | Path to Tomcat home (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`)                                                                    | `/opt/tomcat`                |
+| `app_tomcat_mode`                 | Yes                | Tomcat mode: `direct` or `shared` (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`)                                                      | `direct`                     |
+| `app_tomcat_setup`                | Yes                | Let RPM update customer's tomcat configuration like ports (only if using a custom Tomcat - `app_use_talend_tomcat` = `no`)                              | `no`                         |
+| `tds_kafka_host`                  | No                 | Host of Kafka broker                                                                                                                                    | `localhost`                  |
+| `tds_kafka_port`                  | No                 | Port of Kafka broker                                                                                                                                    | `9092`                       |
+| `tds_mongo_host`                  | No                 | Host of MongoDB                                                                                                                                         | `localhost`                  |
+| `tds_mongo_port`                  | No                 | Port of MongoDB                                                                                                                                         | `27017`                      |
+| `tds_mongo_database`              | No                 | Name of the TDS MongoDB database                                                                                                                        | `tds`                        |
+| `tds_mongo_username`              | No                 | Username of the TDS MongoDB database                                                                                                                    | `tds-user`                   |
+| `tds_mongo_password`              | No                 | Password of the TDS MongoDB database. Default values for security settings must be changed                                                              | `duser`                      |
+| `tds_audit_enabled`               | No                 | Enables the audit for TDS. This is taken into account only when `tds_hybrid_mode` = `no`. Possible values are `true` and `false`.                       | `true`                       |
+| `tds_appender_http_url`           | No                 | URL for http log appender.                                                                                                                              | `http://localhost:8057/`     |
+| `tds_security_scim_url`           | No                 | URL to Talend Identity and Access Management SCIM                                                                                                       | `http://localhost:9080/scim` |
+| `tds_security_oidc_url`           | No                 | URL to Talend Identity and Access Management                                                                                                            | `http://localhost:9080/oidc` |
+| `tds_security_oidc_user_auth_url` | No                 | URL to Talend Identity and Access Management User Authentication                                                                                        | `http://localhost:9080/oidc` |
+| `tds_use_semantic_dictionary`     | No                 | Enable link with Talend Dictionary Service: `yes` (only if you have a license) or `no`                                                                  | `yes`                        |
+| `tds_semantic_dictionary_url`     | No                 | URL of Talend Dictionary Service                                                                                                                        | `http://localhost:8187`      |
+| `tds_use_tdp_switch`              | No                 | Enable Talend Data Preparation app switch: `yes` (only if you have a license) or `no`                                                                   | no                           |
+| `tds_front_tdp_url`               | No                 | URL of Talend Data Preparation                                                                                                                          | `http://localhost:9999`      |
+| `tds_language`                    | No                 | Set the language. Supported values: `en-US` or `fr-FR` or `ja-JP` or `zh-CN`                                                                            | `en-US`                      |
+| `tds_hybrid_mode`                 | No                 | Installation of TDS in Hybrid mode. Available values are `yes` and `no`                                                                                 | `no`                         |
+| `tds_hybrid_region`               | No                 | Hybrid region location, can be one of `us`, `eu` or `ap`                                                                                                | `us`                         |
+| `tds_hybrid_data_center`          | No                 | Hybrid data center to use, provider-specific notation (for AWS, can be `us-east-1`, `eu-central-1` or `ap-south-1`)                                     | `us-east-1`                  |
+| `tds_hybrid_cloud_provider`       | No                 | The cloud provider for Hybrid mode, can be either `AWS` or `azure`                                                                                      | `AWS`                        |
+| `tds_oidc_id`                     | No                 | Talend Identity and Access Management OIDC client identifier.<br>For Hybrid mode: Client ID for your account (retrieved from Talend Management Console) | `tl6K6ac7tSE-LQ`             |
+| `tds_oidc_secret`                 | No                 | Talend Identity and Access Management OIDC password.<br>For Hybrid mode: Client Secret for your account (retrieved from Talend Management Console)      | `sLbyFKTzM8F0dTL10mHd3A`     |
 
 ## Connection to Minio / AWS S3
 
-**Talend Data Stewardship** requires connection to Minio (or AWS S3) server to share semantic dictionary with **TSD**.
-If you do not have an existing Minio / AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+**Talend Data Stewardship** requires connection to Minio server (or AWS S3) to share semantic dictionary with **TSD**.
+If you do not have an existing Minio / AWS S3 account, then an embedded Minio server (**minio** role) can be used instead.
 
 The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:
 
-| Parameter      | Description         | Default value                                                    |
-|----------------|---------------------|------------------------------------------------------------------|
-| tds_s3endpoint | AWS S3 endpoint URL | `http://localhost:9000`                                          |
-| tds_s3bucket   | Bucket name         | `default-bucket`                                                 |
-| tds_s3region   | Used AWS S3 region  | `us-east-1` (do not change it if using embedded **minio** role)  |
-| tds_s3user     | AWS S3 access key   | `usr7xJ0agsFq`                                                   |
-| tds_s3pass     | AWS S3 secret key   | `pwd9jYF26Van`                                                   |
-| tds_basepath   | The base path       | *(empty value)*                                                  |
+| Parameter      | Description         | Default value                                                   |
+| -------------- | ------------------- | --------------------------------------------------------------- |
+| tds_s3endpoint | AWS S3 endpoint URL | `http://localhost:9000`                                         |
+| tds_s3bucket   | Bucket name         | `default-bucket`                                                |
+| tds_s3region   | Used AWS S3 region  | `us-east-1` (do not change it if using embedded **minio** role) |
+| tds_s3user     | AWS S3 access key   | `usr7xJ0agsFq`                                                  |
+| tds_s3pass     | AWS S3 secret key   | `pwd9jYF26Van`                                                  |
+| tds_basepath   | The base path       | *(empty value)*                                                 |
 
 ## Dependencies
 

--- a/ansible/roles/tds/defaults/main.yml
+++ b/ansible/roles/tds/defaults/main.yml
@@ -99,3 +99,13 @@ tds_hybrid_mode:        "no"              # Can be "yes" or "no"
 tds_hybrid_region:      "us"              # Can be one of "us", "eu" or "ap"
 tds_hybrid_data_center:     "us-east-1"   # Data center, see AWS docs
 tds_hybrid_cloud_provider:  "AWS"         # Can be "AWS" or "azure"
+
+#####
+# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+#####
+tds_s3endpoint: "http://localhost:9000"
+tds_s3bucket:   "default-bucket"
+tds_s3region:   "us-east-1"
+tds_s3user:     "usr7xJ0agsFq"
+tds_s3pass:     "pwd9jYF26Van"
+tds_basepath:   ""

--- a/ansible/roles/tds/defaults/main.yml
+++ b/ansible/roles/tds/defaults/main.yml
@@ -101,7 +101,7 @@ tds_hybrid_data_center:     "us-east-1"   # Data center, see AWS docs
 tds_hybrid_cloud_provider:  "AWS"         # Can be "AWS" or "azure"
 
 #####
-# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
 #####
 tds_s3endpoint: "http://localhost:9000"
 tds_s3bucket:   "default-bucket"

--- a/ansible/roles/tds/defaults/main.yml
+++ b/ansible/roles/tds/defaults/main.yml
@@ -54,7 +54,7 @@ tds_mongo_password: "duser"
 #####
 # Audit log settings (will be used only for non-hybrid mode)
 #####
-tds_audit_enabled:     "true"
+tds_audit_enabled: "true"
 tds_appender_http_url: "http://localhost:8057/"
 
 #####
@@ -93,19 +93,19 @@ tds_front_tdp_url: "http://localhost:9999" # Change the port value if you change
 tds_language: "en-US"
 
 #####
-# Hybrid mode 
+# Hybrid mode
 #####
-tds_hybrid_mode:        "no"              # Can be "yes" or "no"
-tds_hybrid_region:      "us"              # Can be one of "us", "eu" or "ap"
-tds_hybrid_data_center:     "us-east-1"   # Data center, see AWS docs
-tds_hybrid_cloud_provider:  "AWS"         # Can be "AWS" or "azure"
+tds_hybrid_mode: "no" # Can be "yes" or "no"
+tds_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
+tds_hybrid_data_center: "us-east-1" # Data center, see AWS docs
+tds_hybrid_cloud_provider: "AWS" # Can be "AWS" or "azure"
 
 #####
-# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
+# Communication with Minio / AWS S3 (defaults are set to use a local "minio" role)
 #####
 tds_s3endpoint: "http://localhost:9000"
-tds_s3bucket:   "default-bucket"
-tds_s3region:   "us-east-1"
-tds_s3user:     "usr7xJ0agsFq"
-tds_s3pass:     "pwd9jYF26Van"
-tds_basepath:   ""
+tds_s3bucket: "default-bucket"
+tds_s3region: "us-east-1"
+tds_s3user: "usr7xJ0agsFq"
+tds_s3pass: "pwd9jYF26Van"
+tds_basepath: ""

--- a/ansible/roles/tds/tasks/params_validation.yml
+++ b/ansible/roles/tds/tasks/params_validation.yml
@@ -98,3 +98,8 @@
   fail:
     msg: Wrong value for tds_audit_enabled - can be only 'true' or 'false'
   when: tds_hybrid_mode == "no" and tds_audit_enabled not in ["true", "false"]
+
+- name: Check correct MinIO port (if MinIO is used)
+  fail:
+    msg: Incorrect value tds_s3endpoint, port does not match with variable minio_port
+  when: minio_port is defined and tds_s3endpoint | urlsplit('port') != minio_port

--- a/ansible/roles/tds/tasks/params_validation.yml
+++ b/ansible/roles/tds/tasks/params_validation.yml
@@ -102,4 +102,4 @@
 - name: Check correct MinIO port (if MinIO is used)
   fail:
     msg: Incorrect value tds_s3endpoint, port does not match with variable minio_port
-  when: minio_port is defined and tds_s3endpoint | urlsplit('port') != minio_port
+  when: minio_port is defined and tds_s3endpoint | urlsplit('port') != minio_port | int

--- a/ansible/roles/tds/tasks/update_config_installed.yml
+++ b/ansible/roles/tds/tasks/update_config_installed.yml
@@ -367,3 +367,40 @@
     path: "{{ tds_config_location }}"
     regexp: 'tds\.front\.cloudDeployment='
     state: absent
+
+## AWS S3 communication
+- name: Update AWS S3 endpoint URL
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.s3\.endpoint=.*'
+    replace: '.s3Repository.s3.endpoint={{ tds_s3endpoint }}'
+
+- name: Update AWS S3 bucket URL
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.bucket-url=.*'
+    replace: '.s3Repository.bucket-url=s3://{{ tds_s3bucket }}'
+
+- name: Update AWS S3 username
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.username=.*'
+    replace: '.s3Repository.username={{ tds_s3user }}'
+
+- name: Update AWS S3 password
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tds_s3pass }}'
+
+- name: Update AWS S3 region
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tds_s3pass }}'
+
+- name: Update AWS S3 base path
+  replace:
+    path: "{{ tds_config_location }}"
+    regexp:  '\.s3Repository\.base-path=.*'
+    replace: '.s3Repository.base-path={{ tds_basepath }}'

--- a/ansible/roles/tds/tasks/update_config_installed.yml
+++ b/ansible/roles/tds/tasks/update_config_installed.yml
@@ -396,8 +396,8 @@
 - name: Update AWS S3 region
   replace:
     path: "{{ tds_config_location }}"
-    regexp:  '\.s3Repository\.password=.*'
-    replace: '.s3Repository.password={{ tds_s3pass }}'
+    regexp:  '\.s3Repository\.s3\.region=.*'
+    replace: '.s3Repository.s3.region={{ tds_s3region }}'
 
 - name: Update AWS S3 base path
   replace:

--- a/ansible/roles/tsd/README.md
+++ b/ansible/roles/tsd/README.md
@@ -37,6 +37,21 @@ The parameters with `First Install Only` as `Yes` can only be set at initial ins
 | `tsd_hybrid_mode`       | No                 | Installation in Hybrid mode (see docs for details), available values are `yes` or `no`                                     | `no`                         |
 | `tsd_hybrid_region`     | No                 | For Hybrid mode, specifies a region to use, available values are `us`, `eu` or `ap`                                        | `us`                         |
 
+## Connection to AWS S3
+
+**Talend Semantic Dictionary** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+
+The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+
+| Parameter      | Description        | Default value                                                    |
+|----------------|--------------------|------------------------------------------------------------------|
+| tsd_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
+| tsd_s3bucket   | Bucket name        | `default-bucket`                                                 |
+| tsd_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role   |
+| tsd_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
+| tsd_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
+| tsd_basepath   | The base path      |                                                                  |
+
 ## Dependencies
 
 The following roles must be used to successfully install TSD:

--- a/ansible/roles/tsd/README.md
+++ b/ansible/roles/tsd/README.md
@@ -50,7 +50,7 @@ The following variables control the connection to AWS S3 and by default they are
 | tsd_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role   |
 | tsd_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
 | tsd_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
-| tsd_basepath   | The base path      |                                                                  |
+| tsd_basepath   | The base path      | *(empty value)*                                                  |
 
 ## Dependencies
 

--- a/ansible/roles/tsd/README.md
+++ b/ansible/roles/tsd/README.md
@@ -47,7 +47,7 @@ The following variables control the connection to AWS S3 and by default they are
 |----------------|--------------------|------------------------------------------------------------------|
 | tsd_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
 | tsd_s3bucket   | Bucket name        | `default-bucket`                                                 |
-| tsd_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role   |
+| tsd_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
 | tsd_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
 | tsd_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
 | tsd_basepath   | The base path      | *(empty value)*                                                  |

--- a/ansible/roles/tsd/README.md
+++ b/ansible/roles/tsd/README.md
@@ -37,20 +37,21 @@ The parameters with `First Install Only` as `Yes` can only be set at initial ins
 | `tsd_hybrid_mode`       | No                 | Installation in Hybrid mode (see docs for details), available values are `yes` or `no`                                     | `no`                         |
 | `tsd_hybrid_region`     | No                 | For Hybrid mode, specifies a region to use, available values are `us`, `eu` or `ap`                                        | `us`                         |
 
-## Connection to AWS S3
+## Connection to Minio / AWS S3 service
 
-**Talend Semantic Dictionary** requires connection to AWS S3 server. If you do not have an existing AWS S3 account, then embedded Minio server (**minio** role) can be used instead.
+**Talend Semantic Dictionary** new architecture relies on Minio (or AWS S3) server to share semantic dictionaries.
+If you do not have an existing Minio (or AWS S3) account, then embedded Minio server (**minio** role) can be used instead.
 
-The following variables control the connection to AWS S3 and by default they are set to use embedded **minio** role:
+The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:
 
-| Parameter      | Description        | Default value                                                    |
-|----------------|--------------------|------------------------------------------------------------------|
-| tsd_s3endpoint | S3 endpoint URL    | `http://localhost:9000`                                          |
-| tsd_s3bucket   | Bucket name        | `default-bucket`                                                 |
-| tsd_s3region   | Used AWS S3 region | `us-east-1` (do not change it if using embedded **minio** role)  |
-| tsd_s3user     | AWS S3 access key  | `usr7xJ0agsFq`                                                   |
-| tsd_s3pass     | AWS S3 secret key  | `pwd9jYF26Van`                                                   |
-| tsd_basepath   | The base path      | *(empty value)*                                                  |
+| Parameter      | Description         | Default value                                                    |
+|----------------|---------------------|------------------------------------------------------------------|
+| tsd_s3endpoint | AWS S3 endpoint URL | `http://localhost:9000`                                          |
+| tsd_s3bucket   | Bucket name         | `default-bucket`                                                 |
+| tsd_s3region   | Used AWS S3 region  | `us-east-1` (do not change it if using embedded **minio** role)  |
+| tsd_s3user     | AWS S3 access key   | `usr7xJ0agsFq`                                                   |
+| tsd_s3pass     | AWS S3 secret key   | `pwd9jYF26Van`                                                   |
+| tsd_basepath   | The base path       | *(empty value)*                                                  |
 
 ## Dependencies
 

--- a/ansible/roles/tsd/README.md
+++ b/ansible/roles/tsd/README.md
@@ -39,7 +39,7 @@ The parameters with `First Install Only` as `Yes` can only be set at initial ins
 
 ## Connection to Minio / AWS S3 service
 
-**Talend Semantic Dictionary** new architecture relies on Minio (or AWS S3) server to share semantic dictionaries.
+**Talend Dictionary Service** new architecture relies on Minio (or AWS S3) server to share semantic dictionaries.
 If you do not have an existing Minio (or AWS S3) account, then embedded Minio server (**minio** role) can be used instead.
 
 The following variables control the connection to Minio / AWS S3 and by default they are set to use embedded **minio** role:

--- a/ansible/roles/tsd/defaults/main.yml
+++ b/ansible/roles/tsd/defaults/main.yml
@@ -77,7 +77,7 @@ tsd_hybrid_mode:   "no"   # Can be "yes" or "no"
 tsd_hybrid_region: "us"   # Can be one of "us", "eu" or "ap"
 
 #####
-# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
 #####
 tsd_s3endpoint: "http://localhost:9000"
 tsd_s3bucket:   "default-bucket"

--- a/ansible/roles/tsd/defaults/main.yml
+++ b/ansible/roles/tsd/defaults/main.yml
@@ -75,3 +75,13 @@ tsd_oidc_secret: "sLbyFKTzM8F0dTL10mHd3A"
 #####
 tsd_hybrid_mode:   "no"   # Can be "yes" or "no"
 tsd_hybrid_region: "us"   # Can be one of "us", "eu" or "ap"
+
+#####
+# Communication with AWS S3 (defaults are set for using a local MinIO RPM)
+#####
+tsd_s3endpoint: "http://localhost:9000"
+tsd_s3bucket:   "default-bucket"
+tsd_s3region:   "us-east-1"
+tsd_s3user:     "usr7xJ0agsFq"
+tsd_s3pass:     "pwd9jYF26Van"
+tsd_basepath:   ""

--- a/ansible/roles/tsd/defaults/main.yml
+++ b/ansible/roles/tsd/defaults/main.yml
@@ -73,15 +73,15 @@ tsd_oidc_secret: "sLbyFKTzM8F0dTL10mHd3A"
 #####
 # Hybrid mode support
 #####
-tsd_hybrid_mode:   "no"   # Can be "yes" or "no"
-tsd_hybrid_region: "us"   # Can be one of "us", "eu" or "ap"
+tsd_hybrid_mode: "no" # Can be "yes" or "no"
+tsd_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
 
 #####
-# Communication with Minio / AWS S3 (defaults are set for using a local "minio" role)
+# Communication with Minio / AWS S3 (defaults are set to use a local "minio" role)
 #####
 tsd_s3endpoint: "http://localhost:9000"
-tsd_s3bucket:   "default-bucket"
-tsd_s3region:   "us-east-1"
-tsd_s3user:     "usr7xJ0agsFq"
-tsd_s3pass:     "pwd9jYF26Van"
-tsd_basepath:   ""
+tsd_s3bucket: "default-bucket"
+tsd_s3region: "us-east-1"
+tsd_s3user: "usr7xJ0agsFq"
+tsd_s3pass: "pwd9jYF26Van"
+tsd_basepath: ""

--- a/ansible/roles/tsd/tasks/params_validation.yml
+++ b/ansible/roles/tsd/tasks/params_validation.yml
@@ -79,3 +79,8 @@
   fail:
     msg: Wrong hybrid region ! Can be one of 'us', 'eu' or 'ap'
   when: tsd_hybrid_mode == 'yes' and not (tsd_hybrid_region == 'us' or tsd_hybrid_region == 'eu' or tsd_hybrid_region == 'ap')
+
+- name: Check correct MinIO port (if MinIO is used)
+  fail:
+    msg: Incorrect value tsd_s3endpoint, port does not match with variable minio_port
+  when: minio_port is defined and tsd_s3endpoint | urlsplit('port') != minio_port

--- a/ansible/roles/tsd/tasks/params_validation.yml
+++ b/ansible/roles/tsd/tasks/params_validation.yml
@@ -83,4 +83,4 @@
 - name: Check correct MinIO port (if MinIO is used)
   fail:
     msg: Incorrect value tsd_s3endpoint, port does not match with variable minio_port
-  when: minio_port is defined and tsd_s3endpoint | urlsplit('port') != minio_port
+  when: minio_port is defined and tsd_s3endpoint | urlsplit('port') != minio_port | int

--- a/ansible/roles/tsd/tasks/update_config_installed.yml
+++ b/ansible/roles/tsd/tasks/update_config_installed.yml
@@ -51,32 +51,32 @@
 - name: Update MongoDB hosts
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '^dq\.mongo\.host=.*'
-    replace: 'dq.mongo.host={{ tsd_mongo_host }}'
+    regexp:  '\.mongodb\.host=.*'
+    replace: '.mongodb.host={{ tsd_mongo_host }}'
 
 - name: Update MongoDB port
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '^dq\.mongo\.port=.*'
-    replace: 'dq.mongo.port={{ tsd_mongo_port }}'
+    regexp:  '\.mongodb\.port=.*'
+    replace: '.mongodb.port={{ tsd_mongo_port }}'
 
 - name: Update MongoDB dbname
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '^dq\.mongo\.database\.name=.*'
-    replace: 'dq.mongo.database.name={{ tsd_mongo_database }}'
+    regexp:  '\.mongodb\.database=.*'
+    replace: '.mongodb.database={{ tsd_mongo_database }}'
 
 - name: Update MongoDB user
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '^dq\.mongo\.username=.*'
-    replace: 'dq.mongo.username={{ tsd_mongo_username }}'
+    regexp:  '\.mongodb\.username=.*'
+    replace: '.mongodb.username={{ tsd_mongo_username }}'
 
 - name: Update MongoDB password
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '^dq\.mongo\.password=.*'
-    replace: 'dq.mongo.password={{ tsd_mongo_password }}'
+    regexp:  '\.mongodb\.password=.*'
+    replace: '.mongodb.password={{ tsd_mongo_password }}'
 
 
 # Security / authentication
@@ -194,8 +194,8 @@
 - name: Update AWS S3 region
   replace:
     path: "{{ tsd_config_location }}"
-    regexp:  '\.s3Repository\.password=.*'
-    replace: '.s3Repository.password={{ tsd_s3pass }}'
+    regexp:  '\.s3Repository\.s3\.region=.*'
+    replace: '.s3Repository.s3.region={{ tsd_s3region }}'
 
 - name: Update AWS S3 base path
   replace:

--- a/ansible/roles/tsd/tasks/update_config_installed.yml
+++ b/ansible/roles/tsd/tasks/update_config_installed.yml
@@ -166,3 +166,39 @@
     regexp: 'audit\.log\.enabled='
     line: "audit.log.enabled=true"
 
+## AWS S3 communication
+- name: Update AWS S3 endpoint URL
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.s3\.endpoint=.*'
+    replace: '.s3Repository.s3.endpoint={{ tsd_s3endpoint }}'
+
+- name: Update AWS S3 bucket URL
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.bucket-url=.*'
+    replace: '.s3Repository.bucket-url=s3://{{ tsd_s3bucket }}'
+
+- name: Update AWS S3 username
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.username=.*'
+    replace: '.s3Repository.username={{ tsd_s3user }}'
+
+- name: Update AWS S3 password
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tsd_s3pass }}'
+
+- name: Update AWS S3 region
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.password=.*'
+    replace: '.s3Repository.password={{ tsd_s3pass }}'
+
+- name: Update AWS S3 base path
+  replace:
+    path: "{{ tsd_config_location }}"
+    regexp:  '\.s3Repository\.base-path=.*'
+    replace: '.s3Repository.base-path={{ tsd_basepath }}'

--- a/ansible/talend.yml
+++ b/ansible/talend.yml
@@ -7,6 +7,7 @@
       - tomcat
       - kafka
       - mongodb
+      - minio
       - jobserver
       - tac
       - amc


### PR DESCRIPTION
TSD new architecture relies on Minio to share semantic dictionaries.
This PR introduces the following changes:
- new "minio" role (to use a local Minio server)
- added corresponding variables to tsd, tds and tdp roles
- updated readme files for tsd, tds and tdp roles (added description for new variables related with minio)
- updated a root readme file (added the description of new "minio" role)
- (small other fix) TAC H2 connection URL string is updated as old one did not work now