### PR TITLE
TINSTL-2412 - improve compatibility with Platform installer

### DIFF
--- a/ansible/roles/tdp/README.md
+++ b/ansible/roles/tdp/README.md
@@ -49,6 +49,14 @@ For hybrid mode, it is important to set up also these 2 variables:
 | `tdp_security_oauth2_client_clientSecret` | Client Secret for your account (retrieved from Talend Management Console) |
 Note: in non-hybrid mode, these two variables should be set to Talend IAM OIDC client identifier and client secret.
 
+### Language
+
+Talend Data Preparation supports the following languages: English (en-US), French (fr-FR), Japanese (jp-JP) and Chinese (zh-CN). This setting is ignored in Hybrid configuration as in this case language setting is stored in the cloud account configuration.
+
+| Parameter           | Description                            | Value               |
+| ------------------- | -------------------------------------- | ------------------- |
+| `tdp_language`   | Language (`en-US`, `fr-FR`, `jp-JP` or `zh-CN` | Default value: `en-US` |
+
 
 ### IAM configuration
 
@@ -162,7 +170,15 @@ The live dataset feature allows creating a job in Talend Studio, executing it on
 | `tdp_dataquality_semantic_update_enable`       | Whether to receive data quality updates (for 7.1 only) | Possible values: `true` (default) or `false`                       |
 | `tdp_tsd_consumer_enabled`                     | Whether to receive data quality updates (for 7.2 only) | Possible values: `true` or `false` (default)                       |
 | `tdp_dataquality_event_store`                  | *Do not modify*                                        | Only possible value: `mongodb`                                     |
-| `tdp_spring_cloud_stream_kafka_binder_brokers` | Host of Kafka server                                   | Default value: `localhost`                                         |
+
+### Kafka connection settings
+
+| Parameter                                      | Description                                            | Value                                 |
+| ---------------------------------------------- | ------------------------------------------------------ | ------------------------------------- |
+| `tdp_spring_cloud_stream_kafka_binder_brokers` | Host of Kafka server                 | Default value: `localhost`      |
+| `tdp_spring_cloud_stream_kafka_binder_defaultbrokerport` | Port of Kafka server     | Default value: `9092`            |
+| `tdp_spring_cloud_stream_kafka_binder_zknodes`  | Host of Zookeeper server            | Default value: `localhost`      |
+| `tdp_spring_cloud_stream_kafka_binder_defaultzkport` | Port of Zookeeper server      | Default value: `2181`            |
 
 ### Single Sign-On (SSO) security configuration parameters
 

--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -24,10 +24,11 @@ tdp_server_port: "9999"
 tdp_iam_ip: "localhost" # IAM host to be used (will be used only for non-hybrid configuration, otherwise ignored)
 tdp_iam_port: "9080" # IAM port to be used (will be used only for non-hybrid configuration, otherwise ignored)
 
+tdp_language: "en-US"
 tdp_async_runtime_contextPath: "/api"
 tdp_server_compression_enabled: "true"
 tdp_server_compression_mime_types: "text/plain,text/html,text/css,application/json,application/x-javascript,text/xml,application/xml,application/xml+rss,text/javascript,application/javascript,text/x-js"
-tdp_spring_mvc_async_request_timeout: "300000"
+tdp_spring_mvc_async_request_timeout: "600000"
 tdp_lock_store: "mongodb"
 tdp_dataprep_event_listener: "spring"
 tdp_live_dataset_location: "tac"
@@ -48,7 +49,7 @@ tdp_spring_http_multipart_maxFileSize: "200000000"
 tdp_spring_http_multipart_maxRequestSize: "200000000"
 tdp_dataset_records_limit: "10000"
 tdp_dataset_local_file_size_limit: "2000000000"
-tdp_dataset_imports: "local,job,tcomp-JDBCDatastore,tcomp-SimpleFileIoDatastore,tcomp-SalesforceDatastore,tcomp-S3Datastore"
+tdp_dataset_imports: "local,tcomp-JDBCDatastore,tcomp-SimpleFileIoDatastore,tcomp-SalesforceDatastore,tcomp-S3Datastore,tcomp-AzureDlsGen2BlobDatastore"
 tdp_dataset_list_limit: "10"
 tdp_content_service_store: "local"
 tdp_content_service_store_local_path: "data/"
@@ -69,7 +70,6 @@ tdp_dataquality_semantic_list_enable: "true"
 tdp_dataquality_semantic_update_enable: "true"
 tdp_tsd_consumer_enabled: "false"
 tdp_dataquality_event_store: "mongodb"
-tdp_spring_cloud_stream_kafka_binder_brokers: "localhost"
 tdp_security_basic_enabled: "false"
 tdp_security_oidc_client_expectedIssuer: "${iam.uri}/oidc"
 tdp_iam_license_url: "${iam.uri}/oidc/api"
@@ -78,6 +78,18 @@ tdp_security_oauth2_client_clientId: "64xIVPxviKWSog"
 tdp_security_oauth2_client_clientSecret: "9C0zCjp8yS-eZBqEi-KhBQ"
 tdp_security_oidc_client_claimIssueAtTolerance: "120"
 tdp_security_oauth2_resource_tokenInfoUri: "${iam.uri}/oidc/oauth2/introspect"
+
+# Communication with TDS. Defaults assume we have TDS installer on localhost with default port (19999)
+tdp_app_products: "yes"
+tdp_app0_id: "TDS"
+tdp_app0_name: "Talend Data Stewardship"
+tdp_app0_url: "http://localhost:19999"
+
+# Communication with Kafka/Zookeeper
+tdp_spring_cloud_stream_kafka_binder_brokers: "localhost"
+tdp_spring_cloud_stream_kafka_binder_defaultbrokerport: 9092
+tdp_spring_cloud_stream_kafka_binder_zknodes: "localhost"
+tdp_spring_cloud_stream_kafka_binder_defaultzkport: 2181
 
 # Set tdp_security_oauth2_resource_uri ONLY if you are know what you are doing ! Otherwise it will use the default setting from RPM/zip
 tdp_security_oauth2_resource_uri: ""

--- a/ansible/roles/tdp/tasks/params_validation.yml
+++ b/ansible/roles/tdp/tasks/params_validation.yml
@@ -183,3 +183,13 @@
   fail:
     msg: Incorrect value tdp_s3endpoint, port does not match with variable minio_port
   when: minio_port is defined and tdp_s3endpoint | urlsplit('port') != minio_port | int
+
+- name: Check correct language setting
+  fail:
+    msg: tdp_language can be one of en-US, fr-FR, jp-JP or zh-CN
+  when: tdp_language != 'en-US' and tdp_language != 'fr-FR' and tdp_language != 'jp-JP' and tdp_language != 'zh-CN'
+
+- name: Check correct value for tdp_app_products
+  fail:
+    msg: tdp_app_products can be only one of "yes" or "no"
+  when: tdp_app_products != "yes" and tdp_app_products != "no"

--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -11,6 +11,13 @@
       regexp: "server.port=.*"
       replace: "server.port={{ tdp_server_port }}"
 
+- name: Modify Data Preparation language setting
+  when: tdp_hybrid_mode == 'no'
+  replace:
+      path: "/etc/talend/tdp/application.properties"
+      regexp: '^#?dataprep\.locale=.*'
+      replace: "dataprep.locale={{ tdp_language }}"
+
 - name: Modify Data Preparation async runtime contextPath
   replace:
       path: "/etc/talend/tdp/application.properties"
@@ -297,12 +304,6 @@
       regexp: "dataquality.event.store=.*"
       replace: "dataquality.event.store={{ tdp_dataquality_event_store }}"
 
-- name: Modify Data Preparation spring cloud stream kafka binder brokers
-  replace:
-      path: "/etc/talend/tdp/application.properties"
-      regexp: "spring.cloud.stream.kafka.binder.brokers=.*"
-      replace: "spring.cloud.stream.kafka.binder.brokers={{ tdp_spring_cloud_stream_kafka_binder_brokers }}"
-
 - name: Modify Data Preparation security basic enabled
   replace:
       path: "/etc/talend/tdp/application.properties"
@@ -379,7 +380,7 @@
 - name: Modify Data Preparation security oauth2 client scope
   replace:
       path: "/etc/talend/tdp/application.properties"
-      regexp: "security.oauth2.client.scope=.*"
+      regexp: '^security\.oauth2\.client\.scope=.*'
       replace: "security.oauth2.client.scope={{ tdp_security_oauth2_client_scope }}"
 
 - name: Modify Data Preparation security oauth2 client user authorization uri
@@ -656,7 +657,7 @@
 - name: Modify Data Preparation dataset service provider
   replace:
       path: "/etc/talend/tdp/application.properties"
-      regexp: "dataset.service.provider=.*"
+      regexp: "^dataset.service.provider=.*"
       replace: "dataset.service.provider={{ tdp_dataset_service_provider }}"
 
 - name: Modify Data Preparation spring cloud stream bindings dqDictionary group
@@ -983,3 +984,50 @@
     path: "/etc/talend/tdp/application.properties"
     regexp:  '\.s3Repository\.base-path=.*'
     replace: '.s3Repository.base-path={{ tdp_basepath }}'
+
+# Commmunication with TDS
+- name: Update app.products id
+  when: tdp_app_products == "yes"
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?app\.products\[0\]\.id=.*'
+    replace: "app.products[0].id={{ tdp_app0_id }}"
+
+- name: Update app.products name
+  when: tdp_app_products == "yes"
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?app\.products\[0\]\.name=.*'
+    replace: "app.products[0].name={{ tdp_app0_name }}"
+
+- name: Update app.products url
+  when: tdp_app_products == "yes"
+  replace:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?app\.products\[0\]\.url=.*'
+    replace: "app.products[0].url={{ tdp_app0_url }}"
+
+# Add info about kafka.binder
+- name: Modify Data Preparation spring cloud stream kafka binder brokers
+  lineinfile:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?spring\.cloud\.stream\.kafka\.binder\.brokers=.*'
+    line: "spring.cloud.stream.kafka.binder.brokers={{ tdp_spring_cloud_stream_kafka_binder_brokers }}"
+
+- name: Update kafka.binder.defaultBrokerPort
+  lineinfile:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?spring\.cloud\.stream\.kafka\.binder\.defaultBrokerPort=.*'
+    line: "spring.cloud.stream.kafka.binder.defaultBrokerPort={{ tdp_spring_cloud_stream_kafka_binder_defaultbrokerport }}"
+
+- name: Update kafka.binder.zkNodes
+  lineinfile:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?spring\.cloud\.stream\.kafka\.binder\.zkNodes=.*'
+    line: "spring.cloud.stream.kafka.binder.zkNodes={{ tdp_spring_cloud_stream_kafka_binder_zknodes }}"
+
+- name: Update kafka.binder.defaultZkPort
+  lineinfile:
+    path: "/etc/talend/tdp/application.properties"
+    regexp: '^#?spring\.cloud\.stream\.kafka\.binder\.defaultZkPort=.*'
+    line: "spring.cloud.stream.kafka.binder.defaultZkPort={{ tdp_spring_cloud_stream_kafka_binder_defaultzkport }}"


### PR DESCRIPTION
There were several differences in TDP application.properties file when installed in RPM or in Platform installer (and Platform installer is a base).
This PR eliminates these differences as much as possible.
Extra information: https://jira.talendforge.org/browse/TINSTL-2412
Testing: successfully performed with the following content of talend.yml:
`---
- hosts: tac-group
  become: yes
  roles:
      - java
      - talend-repo
      - tomcat
      - kafka
      - mongodb
      - minio
      - tac
      - filebeat
      - iam
      - tdp
      - tds
      - tsd
`