### PR TITLE
TINSTL-2403 - MDM installation requires Talend license

### DIFF
--- a/ansible/roles/mdm/README.md
+++ b/ansible/roles/mdm/README.md
@@ -34,11 +34,11 @@ Before running the script, you can change the following variables in the *defaul
 
 ### License
 
-MDM requires a Talend license to work. The next parameter is mandatory, installation would fail if it is left as default.
+MDM requires a Talend license to install and run.
 
 | Parameter         | Description                     | Value                      |
 | ----------------- | ------------------------------- | -------------------------- |
-| `mdm_license_file` | Talend license file to use (must be on a controller host) | Default value: `""` |
+| `mdm_license_file` | Talend license file to use | Required. Local path to license file on controller host |
 
 ### MDM configuration updates
 

--- a/ansible/roles/mdm/README.md
+++ b/ansible/roles/mdm/README.md
@@ -32,6 +32,14 @@ Before running the script, you can change the following variables in the *defaul
 | ----------------- | ------------------------------- | -------------------------- |
 | `mdm_webapp_name` | Name of the MDM Web application | Default value: `talendmdm` |
 
+### License
+
+MDM requires a Talend license to work. The next parameter is mandatory, installation would fail if it is left as default.
+
+| Parameter         | Description                     | Value                      |
+| ----------------- | ------------------------------- | -------------------------- |
+| `mdm_license_file` | Talend license file to use (must be on a controller host) | Default value: `""` |
+
 ### MDM configuration updates
 
 | Parameter               | Description                                          | Value                           |

--- a/ansible/roles/mdm/defaults/main.yml
+++ b/ansible/roles/mdm/defaults/main.yml
@@ -52,6 +52,11 @@ mdm_webapp_name: talendmdm
 # Parameters below can be used for configuration updates (re-configuration) "on the fly"
 #
 #########################################
+
+# Talend license file to use. Note that file must be on the controller host (local file)
+# It is a mandatory parameter and MDM installation would fail if it is left empty
+mdm_license_file: ""
+
 # Use Audit enablement for Talend LogServer
 mdm_audit_log_enabled: "yes" # allowed values 'yes' or 'no'
 mdm_audit_server_host: "localhost"

--- a/ansible/roles/mdm/defaults/main.yml
+++ b/ansible/roles/mdm/defaults/main.yml
@@ -54,7 +54,7 @@ mdm_webapp_name: talendmdm
 #########################################
 
 # Talend license file to use. Note that file must be on the controller host (local file)
-# It is a mandatory parameter and MDM installation would fail if it is left empty
+# It is a mandatory parameter and MDM installation will fail if it is left empty
 mdm_license_file: ""
 
 # Use Audit enablement for Talend LogServer

--- a/ansible/roles/mdm/tasks/params_validation.yml
+++ b/ansible/roles/mdm/tasks/params_validation.yml
@@ -19,3 +19,17 @@
   fail:
     msg: Wrong value for parameter "mdm_db_driver", must be valid JAR when "mdm_database" is not 'h2'
   when: mdm_db_driver == "" and mdm_database != "h2"
+
+- name: Show error about wrong value for parameter mdm_license_file
+  fail:
+    msg: Wrong value for parameter "mdm_license_file", must be a valid Talend license file
+  when: mdm_license_file == ""
+
+- name: Get info about local license file for MDM
+  local_action: stat path="{{ mdm_license_file }}"
+  register: mdm_license_file_stat
+
+- name: Show error about inaccessible license file for MDM
+  fail:
+    msg: "Could not find MDM license file '{{ mdm_license_file }}'"
+  when: not mdm_license_file_stat.stat.exists

--- a/ansible/roles/mdm/tasks/update_config_installed.yml
+++ b/ansible/roles/mdm/tasks/update_config_installed.yml
@@ -596,3 +596,13 @@
     path: "{{ mdm_tomcat_config_location }}/data-authoring-proxy.properties"
     regexp: '\$\{tinstall\.tdp\.url\}'
     replace: "{{ mdm_tdp_url }}"
+
+# Copy license file to MDM
+
+- name: Copy license file to MDM
+  copy:
+    src: "{{mdm_license_file}}"
+    dest: "{{ install_prefix + '/' + rpm_folder + '/license' }}"
+    owner: "{{install_user}}"
+    group: "{{install_group}}"
+    mode: '0640'


### PR DESCRIPTION
It was found that MDM installation does not handle Talend license file (normally it should be copied in MDM home folder under file named "license"). Missing this step caused some issues (for example https://jira.talendforge.org/browse/TINSTL-2403)
