### PR TITLE
Updated cloud region list for Hybrid installation mode

### DIFF
--- a/ansible/roles/tdp/defaults/main.yml
+++ b/ansible/roles/tdp/defaults/main.yml
@@ -161,7 +161,7 @@ tdp_appender_http_async: "true"
 
 # Hybrid mode
 tdp_hybrid_mode: "no" # Can be "yes" or "no"
-tdp_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
+tdp_hybrid_region: "us" # Can be one of "us", "eu", "ap", "au", "us-west" or "at"
 
 #####
 # Communication with Minio / AWS S3 (defaults are set to use a local "minio" role)

--- a/ansible/roles/tdp/tasks/params_validation.yml
+++ b/ansible/roles/tdp/tasks/params_validation.yml
@@ -176,8 +176,8 @@
 
 - name: Show error about wrong value for parameter tdp_hybrid_region
   fail:
-    msg: Wrong value for parameter "tdp_hybrid_region", must be one of "us", "eu" or "ap"
-  when: tdp_hybrid_region != "us" and tdp_hybrid_region != "eu" and tdp_hybrid_region != "ap"
+    msg: Wrong value for parameter "tdp_hybrid_region", must be one of "us", "eu", "ap", "au", "us-west" or "at"
+  when: tdp_hybrid_region != "us" and tdp_hybrid_region != "eu" and tdp_hybrid_region != "ap" and tdp_hybrid_region != "au" and tdp_hybrid_region != "at" and tdp_hybrid_region != "us-west"
 
 - name: Check correct MinIO port (if MinIO is used)
   fail:

--- a/ansible/roles/tds/defaults/main.yml
+++ b/ansible/roles/tds/defaults/main.yml
@@ -96,7 +96,7 @@ tds_language: "en-US"
 # Hybrid mode
 #####
 tds_hybrid_mode: "no" # Can be "yes" or "no"
-tds_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
+tds_hybrid_region: "us" # Can be one of "us", "eu", "ap", "au", "us-west" or "at"
 tds_hybrid_data_center: "us-east-1" # Data center, see AWS docs
 tds_hybrid_cloud_provider: "AWS" # Can be "AWS" or "azure"
 

--- a/ansible/roles/tds/tasks/params_validation.yml
+++ b/ansible/roles/tds/tasks/params_validation.yml
@@ -40,13 +40,23 @@
 
 - name: Show error about wrong value for parameter tds_hybrid_region
   fail:
-    msg: Wrong value for parameter "tds_hybrid_region", must be one of 'us', 'eu' or 'ap'
-  when: tds_hybrid_region != "us" and tds_hybrid_region != "eu" and tds_hybrid_region != "ap"
+    msg: Wrong value for parameter "tds_hybrid_region", must be one of 'us', 'eu', 'ap', 'au', 'us-west' or 'at'
+  when: tds_hybrid_region != "us" and tds_hybrid_region != "eu" and tds_hybrid_region != "ap" and tds_hybrid_region != "au" and tds_hybrid_region != "at" and tds_hybrid_region != "us-west"
 
 - name: Show error about wrong value for parameter tds_hybrid_cloud_provider
   fail:
     msg: Wrong value for parameter "tds_hybrid_cloud_provider", must be 'AWS' or 'azure'
   when: tds_hybrid_cloud_provider != "AWS" and tds_hybrid_cloud_provider != "azure"
+
+- name: Show error about wrong value for parameter tds_hybrid_cloud_provider (2)
+  fail:
+    msg: Wrong value for parameter "tds_hybrid_cloud_provider", must be 'azure' for 'us-west' region
+  when: tds_hybrid_cloud_provider != "azure" and tds_hybrid_region == "us-west"
+
+- name: Show error about wrong value for parameter tds_hybrid_cloud_provider (3)
+  fail:
+    msg: Wrong value for parameter "tds_hybrid_cloud_provider", must be 'AWS' for anything except 'us-west' region
+  when: tds_hybrid_cloud_provider != "AWS" and tds_hybrid_region != "us-west"
 
 # specific non empty check for tds_front_tdp_url
 - name: Show error that no value is specified for tds_front_tdp_url when tds_use_tdp_switch is 'yes'

--- a/ansible/roles/tsd/defaults/main.yml
+++ b/ansible/roles/tsd/defaults/main.yml
@@ -80,7 +80,7 @@ tsd_oidc_secret: "sLbyFKTzM8F0dTL10mHd3A"
 # Hybrid mode support
 #####
 tsd_hybrid_mode: "no" # Can be "yes" or "no"
-tsd_hybrid_region: "us" # Can be one of "us", "eu" or "ap"
+tsd_hybrid_region: "us" # Can be one of "us", "eu", "ap", "au", "us-west" or "at"
 
 #####
 # Communication with Minio / AWS S3 (defaults are set to use a local "minio" role)

--- a/ansible/roles/tsd/tasks/params_validation.yml
+++ b/ansible/roles/tsd/tasks/params_validation.yml
@@ -77,8 +77,8 @@
 
 - name: Show error about wrong hybrid region
   fail:
-    msg: Wrong hybrid region ! Can be one of 'us', 'eu' or 'ap'
-  when: tsd_hybrid_mode == 'yes' and not (tsd_hybrid_region == 'us' or tsd_hybrid_region == 'eu' or tsd_hybrid_region == 'ap')
+    msg: Wrong hybrid region ! Can be one of 'us', 'eu', 'ap', 'au', 'us-west' or 'at'
+  when: tsd_hybrid_mode == 'yes' and not (tsd_hybrid_region == 'us' or tsd_hybrid_region == 'eu' or tsd_hybrid_region == 'ap' or tsd_hybrid_region == 'au' or tsd_hybrid_region == 'at' or tsd_hybrid_region == 'us-west')
 
 - name: Check correct MinIO port (if MinIO is used)
   fail:


### PR DESCRIPTION
Updated the cloud region list (for Hybrid installation mode), now it will include:
- us
- eu
- ap
- au
- us-west
- at

The list corresponds 1-to-1 with Hybrid installer 8.0.1