### PR TITLE
TINSTL-2452 - Improvements

### DIFF
--- a/ansible/roles/tdp/tasks/update_config_installed.yml
+++ b/ansible/roles/tdp/tasks/update_config_installed.yml
@@ -315,7 +315,7 @@
       replace: "tsd.consumer.enabled={{ tdp_tsd_consumer_enabled }}"
 
 - name: Modify Data Preparation dataquality semantic update enable for 8.0
-  when: rpm_base_version == 8.0
+  when: rpm_base_version >= 8.0
   replace:
       path: "/etc/talend/tdp/application.properties"
       regexp: "tsd.enabled=.*"

--- a/ansible/roles/tds/tasks/update_config_installed.yml
+++ b/ansible/roles/tds/tasks/update_config_installed.yml
@@ -374,14 +374,14 @@
   lineinfile:
     path: "{{ tds_config_location }}"
     regexp: 'tsd\.maven\.connector\.enabled='
-    line: "tsd.maven.connector.enabled={{ tds_use_semantic_dictionary | bool }}"
+    line: "tsd.maven.connector.enabled={{ tds_use_semantic_dictionary | bool | lower }}"
 
 - name: Update TSD connection status (2)
   when: rpm_base_version >= 8.0
   lineinfile:
     path: "{{ tds_config_location }}"
     regexp: 'tsd\.enabled='
-    line: "tsd.enabled={{ tds_use_semantic_dictionary | bool }}"
+    line: "tsd.enabled={{ tds_use_semantic_dictionary | bool | lower }}"
 
 - name: Update AWS S3 endpoint URL
   replace:

--- a/ansible/roles/tds/tasks/update_config_installed.yml
+++ b/ansible/roles/tds/tasks/update_config_installed.yml
@@ -368,7 +368,21 @@
     regexp: 'tds\.front\.cloudDeployment='
     state: absent
 
-## AWS S3 communication
+## AWS S3 communication (TSD)
+- name: Update TSD connection status (1)
+  when: rpm_base_version >= 8.0
+  lineinfile:
+    path: "{{ tds_config_location }}"
+    regexp: 'tsd\.maven\.connector\.enabled='
+    line: "tsd.maven.connector.enabled={{ tds_use_semantic_dictionary | bool }}"
+
+- name: Update TSD connection status (2)
+  when: rpm_base_version >= 8.0
+  lineinfile:
+    path: "{{ tds_config_location }}"
+    regexp: 'tsd\.enabled='
+    line: "tsd.enabled={{ tds_use_semantic_dictionary | bool }}"
+
 - name: Update AWS S3 endpoint URL
   replace:
     path: "{{ tds_config_location }}"


### PR DESCRIPTION
* Improved RPM version handling (">= 8.0" instead of "== 8.0") in TDP role
* In TDS role, added handling for parameters "tsd.enabled" and "tsd.maven.connector.enabled"

Tested on CentOS 7.9, installation in Hybrid mode, all is fine.