### PR TITLE
2022H2 8.0.1 re-release updates

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -18,7 +18,7 @@
 
 rpm_base_version: 8.0
 rpm_patch_version: 1
-rpm_build_number: 202111091610
+rpm_build_number: 202211231200
 
 
 rpm_version: "{{ rpm_base_version }}.{{ rpm_patch_version }}"

--- a/ansible/roles/kafka/tasks/update_acl.yml
+++ b/ansible/roles/kafka/tasks/update_acl.yml
@@ -120,7 +120,7 @@
 - name: Kafka - update configuration file for using ACL (1)
   lineinfile:
     path: "{{ install_prefix }}/kafka/config/server.properties"
-    line: "authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer"
+    line: "authorizer.class.name=kafka.security.authorizer.AclAuthorizer"
     state: present
   when: zook_setacl == 'yes'
 
@@ -158,7 +158,7 @@
 - name: Kafka - update configuration file for de-activating ACL (1)
   lineinfile:
     path: "{{ install_prefix }}/kafka/config/server.properties"
-    line: "authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer"
+    line: "authorizer.class.name=kafka.security.authorizer.AclAuthorizer"
     state: absent
   when: zook_setacl != 'yes'
 


### PR DESCRIPTION
2022H2 8.0.1 re-release
In this PR we perform updates which are needed to run 2022H2 8.0.1 RPM packages:
- updated RPM time-stamp
- updated Kafka role to use Kafka 3.X

As a part of security updates, we will deliver now Kafka 3.2.3 (instead of Kafka 2.8.1). In past we used class kafka.security.auth.SimpleAclAuthorizer which now became obsolete in Kafka 3.X
Instead we will use class kafka.security.authorizer.AclAuthorizer which will work in both cases (Kafka 2.X and Kafka 3.X)
The change was tested on Platform installer side.